### PR TITLE
🔒 fix: sanitize URL parameters for directions map

### DIFF
--- a/src/components/sauna-map/utils.ts
+++ b/src/components/sauna-map/utils.ts
@@ -13,7 +13,9 @@ export function extractPrefecture(area: string | undefined): string | null {
 }
 
 export function getDirectionsUrl(lat: number, lng: number): string {
-  return `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`;
+  const safeLat = encodeURIComponent(Number(lat).toString());
+  const safeLng = encodeURIComponent(Number(lng).toString());
+  return `https://www.google.com/maps/dir/?api=1&destination=${safeLat},${safeLng}`;
 }
 
 export function normalizeVisits(visits: SaunaVisit[]): SaunaVisit[] {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is an unsanitized URL generation in `getDirectionsUrl` inside `src/components/sauna-map/utils.ts`.

⚠️ **Risk:** Although TypeScript types the parameters as `number`, at runtime it could be possible to pass malicious strings, leading to potential URL manipulation or cross-site scripting (XSS) if this URL were used in an unsafe context.

🛡️ **Solution:** The fix casts the `lat` and `lng` parameters to `Number`, ensuring they are indeed valid numeric values (or `NaN`/`Infinity`). It then calls `encodeURIComponent` on their string representation before appending them to the URL string. This guarantees that arbitrary strings are safely handled and the destination parameters are properly formatted.

---
*PR created automatically by Jules for task [13570843097160726885](https://jules.google.com/task/13570843097160726885) started by @handism*