### PR TITLE
🔒 Fix missing runtime type validation for imported JSON data

### DIFF
--- a/logs/pr_proposal.md
+++ b/logs/pr_proposal.md
@@ -1,0 +1,10 @@
+# 🔒 Fix missing runtime type validation for imported JSON data
+
+## 🎯 What
+Added runtime type validation to `importVisitsFromFile` hook using `zod`.
+
+## ⚠️ Risk
+When importing data from a JSON file, the application was using `JSON.parse(text) as SaunaVisit[]`. The `as` keyword just blindly forces a type cast, bypassing any actual checking. If a user was tricked into importing a malicious or malformed JSON payload, the application would have stored corrupted data and potentially crashed when attempting to map through unexpected shapes.
+
+## 🛡️ Solution
+Installed `zod` and created a schema for `SaunaVisit` mapping to the types interface exactly. Updated `importVisitsFromFile` to use `z.array(saunaVisitSchema).safeParse()` instead to ensure we only process perfectly validated `SaunaVisit` entries.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,14 @@
         "react-calendar": "^6.0.0",
         "react-dom": "19.2.3",
         "react-leaflet": "^5.0.0",
-        "recharts": "^3.7.0"
+        "recharts": "^3.7.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "babel-plugin-react-compiler": "1.0.0",
+        "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "typescript": "^5"
@@ -6512,10 +6513,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -19,12 +19,14 @@
     "react-calendar": "^6.0.0",
     "react-dom": "19.2.3",
     "react-leaflet": "^5.0.0",
-    "recharts": "^3.7.0"
+    "recharts": "^3.7.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "typescript": "^5"

--- a/src/components/sauna-map/hooks/useSaunaVisits.ts
+++ b/src/components/sauna-map/hooks/useSaunaVisits.ts
@@ -8,7 +8,8 @@ import {
   getInitialVisits,
   toNormalizedTags,
 } from "../utils";
-import { SaunaVisit, VisitFormState } from "../types";
+import { z } from "zod";
+import { SaunaVisit, VisitFormState, SaunaVisitSchema } from "../types";
 
 function readFileAsText(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -114,9 +115,22 @@ export function useSaunaVisits() {
   const importVisitsFromFile = useCallback(
     async (file: File) => {
       const text = await readFileAsText(file);
-      const parsed = JSON.parse(text) as SaunaVisit[];
+      let parsed;
+      try {
+        parsed = JSON.parse(text);
+      } catch (error) {
+        throw new Error("Invalid JSON file");
+      }
+
+      const validationResult = z.array(SaunaVisitSchema).safeParse(parsed);
+      if (!validationResult.success) {
+        throw new Error("Imported data is not in the correct format for sauna visits: " + validationResult.error.message);
+      }
+
+      const validVisits = validationResult.data;
+
       const existingIds = new Set(visits.map((v) => v.id));
-      const normalizedImported = normalizeVisits(parsed).filter(
+      const normalizedImported = normalizeVisits(validVisits).filter(
         (v) => !existingIds.has(v.id),
       );
 

--- a/src/components/sauna-map/types.ts
+++ b/src/components/sauna-map/types.ts
@@ -1,25 +1,30 @@
-export interface SaunaVisit {
-  id: string;
-  name: string;
-  lat: number;
-  lng: number;
-  comment: string;
-  image?: string;
-  date: string;
-  rating?: number;
-  tags?: string[];
-  status?: "visited" | "wishlist";
-  area?: string;
-  visitCount?: number;
-  history?: VisitHistoryEntry[];
-}
+import { z } from "zod";
 
-export interface VisitHistoryEntry {
-  date: string;
-  comment: string;
-  rating?: number;
-  image?: string;
-}
+export const VisitHistoryEntrySchema = z.object({
+  date: z.string(),
+  comment: z.string(),
+  rating: z.number().optional(),
+  image: z.string().optional(),
+});
+
+export const SaunaVisitSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  lat: z.number(),
+  lng: z.number(),
+  comment: z.string(),
+  image: z.string().optional(),
+  date: z.string(),
+  rating: z.number().optional(),
+  tags: z.array(z.string()).optional(),
+  status: z.enum(["visited", "wishlist"]).optional(),
+  area: z.string().optional(),
+  visitCount: z.number().optional(),
+  history: z.array(VisitHistoryEntrySchema).optional(),
+});
+
+export type SaunaVisit = z.infer<typeof SaunaVisitSchema>;
+export type VisitHistoryEntry = z.infer<typeof VisitHistoryEntrySchema>;
 
 export interface VisitFormState {
   name: string;


### PR DESCRIPTION
Added runtime type validation to `importVisitsFromFile` hook using `zod`. When importing data from a JSON file, the application was using `JSON.parse(text) as SaunaVisit[]`. The `as` keyword just blindly forces a type cast, bypassing any actual checking. If a user was tricked into importing a malicious or malformed JSON payload, the application would have stored corrupted data and potentially crashed when attempting to map through unexpected shapes. Installed `zod` and created a schema for `SaunaVisit` mapping to the types interface exactly. Updated `importVisitsFromFile` to use `z.array(saunaVisitSchema).safeParse()` instead to ensure we only process perfectly validated `SaunaVisit` entries.

---
*PR created automatically by Jules for task [18268065570229088881](https://jules.google.com/task/18268065570229088881) started by @handism*