### PR TITLE
🧪 [testing improvement] Add tests for sanitizeImageUrl

### DIFF
--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,6 +1,0 @@
-# 🧪 [testing improvement] Add tests for sanitizeImageUrl
-
-## Description
-- 🎯 **What:** The testing gap for the `sanitizeImageUrl` utility function in `src/components/sauna-map/utils.ts` has been addressed. The function is pure and didn't have test coverage before.
-- 📊 **Coverage:** The test covers falsy inputs, valid HTTP/HTTPS URLs, relative/absolute paths, valid `data:image/*` URLs, invalid `data:` URLs (e.g., HTML), dangerous protocols (e.g., `javascript:`, `file:`), and unparseable URLs.
-- ✨ **Result:** Test coverage and reliability of the `sanitizeImageUrl` utility function have significantly improved, preventing potential regressions.

--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,0 +1,6 @@
+# 🧪 [testing improvement] Add tests for sanitizeImageUrl
+
+## Description
+- 🎯 **What:** The testing gap for the `sanitizeImageUrl` utility function in `src/components/sauna-map/utils.ts` has been addressed. The function is pure and didn't have test coverage before.
+- 📊 **Coverage:** The test covers falsy inputs, valid HTTP/HTTPS URLs, relative/absolute paths, valid `data:image/*` URLs, invalid `data:` URLs (e.g., HTML), dangerous protocols (e.g., `javascript:`, `file:`), and unparseable URLs.
+- ✨ **Result:** Test coverage and reliability of the `sanitizeImageUrl` utility function have significantly improved, preventing potential regressions.

--- a/src/components/sauna-map/utils.test.ts
+++ b/src/components/sauna-map/utils.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import imageCompression from "browser-image-compression";
-import { normalizeVisits, extractPrefecture, compressAndGetBase64, getVisitHistoryEntries, getVisitCount, calculateStats } from "./utils";
+import { normalizeVisits, extractPrefecture, compressAndGetBase64, getVisitHistoryEntries, getVisitCount, calculateStats, sanitizeImageUrl } from "./utils";
 import { SaunaVisit } from "./types";
 
 vi.mock("browser-image-compression", () => ({
@@ -606,5 +606,42 @@ describe("extractPrefecture", () => {
   it("should return null if the first part doesn't end with suffix", () => {
     expect(extractPrefecture("東京 新宿区")).toBeNull();
     expect(extractPrefecture("Osaka City")).toBeNull();
+  });
+});
+
+describe("sanitizeImageUrl", () => {
+  it("should return undefined for falsy inputs", () => {
+    expect(sanitizeImageUrl(undefined)).toBeUndefined();
+    expect(sanitizeImageUrl("")).toBeUndefined();
+  });
+
+  it("should return the url for valid http and https urls", () => {
+    expect(sanitizeImageUrl("http://example.com/image.jpg")).toBe("http://example.com/image.jpg");
+    expect(sanitizeImageUrl("https://example.com/image.jpg")).toBe("https://example.com/image.jpg");
+  });
+
+  it("should return the url for relative and absolute paths", () => {
+    expect(sanitizeImageUrl("/images/photo.jpg")).toBe("/images/photo.jpg");
+    expect(sanitizeImageUrl("images/photo.jpg")).toBe("images/photo.jpg");
+  });
+
+  it("should return the url for valid data:image/* urls", () => {
+    expect(sanitizeImageUrl("data:image/png;base64,iVBORw0KGgo=")).toBe("data:image/png;base64,iVBORw0KGgo=");
+    expect(sanitizeImageUrl("data:image/jpeg;base64,/9j/4AAQSkZJRgABA=")).toBe("data:image/jpeg;base64,/9j/4AAQSkZJRgABA=");
+  });
+
+  it("should return undefined for invalid data: urls", () => {
+    expect(sanitizeImageUrl("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==")).toBeUndefined();
+  });
+
+  it("should return undefined for dangerous protocols", () => {
+    expect(sanitizeImageUrl("javascript:alert(1)")).toBeUndefined();
+    expect(sanitizeImageUrl("file:///etc/passwd")).toBeUndefined();
+    expect(sanitizeImageUrl("vbscript:msgbox(\"test\")")).toBeUndefined();
+  });
+
+  it("should return undefined for invalid or unparseable URLs", () => {
+    // Using a URL string that might throw during parsing or just fails logic
+    expect(sanitizeImageUrl("http://[::1")).toBeUndefined(); // Invalid IPv6
   });
 });


### PR DESCRIPTION
- 🎯 **What:** The testing gap for the `sanitizeImageUrl` utility function in `src/components/sauna-map/utils.ts` has been addressed. The function is pure and didn't have test coverage before.
- 📊 **Coverage:** The test covers falsy inputs, valid HTTP/HTTPS URLs, relative/absolute paths, valid `data:image/*` URLs, invalid `data:` URLs (e.g., HTML), dangerous protocols (e.g., `javascript:`, `file:`), and unparseable URLs.
- ✨ **Result:** Test coverage and reliability of the `sanitizeImageUrl` utility function have significantly improved, preventing potential regressions.

---
*PR created automatically by Jules for task [100849266134210161](https://jules.google.com/task/100849266134210161) started by @handism*