### PR TITLE
🧹 refactor: Extract inline onDeleteLastHistory to named handler

### DIFF
--- a/src/components/sauna-map/SaunaMap.tsx
+++ b/src/components/sauna-map/SaunaMap.tsx
@@ -144,6 +144,27 @@ export default function SaunaMap() {
     cancelEditing(true);
   };
 
+
+  const handleDeleteLastHistory = () => {
+    if (!editingId) return;
+
+    removeLastHistoryEntry(editingId);
+
+    const visit = visits.find((v) => v.id === editingId);
+    const currentHistory = visit ? getVisitHistoryEntries(visit) : [];
+    const newLatest = currentHistory[currentHistory.length - 2];
+
+    if (newLatest) {
+      setForm((prev) => ({
+        ...prev,
+        date: newLatest.date,
+        comment: newLatest.comment,
+        rating: newLatest.rating ?? 0,
+        image: newLatest.image ?? "",
+      }));
+    }
+  };
+
   const handleLocationSelect = useCallback(
     (lat: number, lng: number) => {
       selectLocation({ lat, lng });
@@ -392,23 +413,7 @@ export default function SaunaMap() {
                   onImageChange={handleImageChange}
                   onDelete={handleDelete}
                   onCancel={() => cancelEditing()}
-                  onDeleteLastHistory={
-                    editingId
-                      ? () => {
-                          removeLastHistoryEntry(editingId);
-                          const newLatest = historyEntries[historyEntries.length - 2];
-                          if (newLatest) {
-                            setForm((prev) => ({
-                              ...prev,
-                              date: newLatest.date,
-                              comment: newLatest.comment,
-                              rating: newLatest.rating ?? 0,
-                              image: newLatest.image ?? "",
-                            }));
-                          }
-                        }
-                      : undefined
-                  }
+                  onDeleteLastHistory={editingId ? handleDeleteLastHistory : undefined}
                 />
               ) : (
                 <VisitList

--- a/src/components/sauna-map/SaunaMap.tsx
+++ b/src/components/sauna-map/SaunaMap.tsx
@@ -145,26 +145,6 @@ export default function SaunaMap() {
   };
 
 
-  const handleDeleteLastHistory = () => {
-    if (!editingId) return;
-
-    removeLastHistoryEntry(editingId);
-
-    const visit = visits.find((v) => v.id === editingId);
-    const currentHistory = visit ? getVisitHistoryEntries(visit) : [];
-    const newLatest = currentHistory[currentHistory.length - 2];
-
-    if (newLatest) {
-      setForm((prev) => ({
-        ...prev,
-        date: newLatest.date,
-        comment: newLatest.comment,
-        rating: newLatest.rating ?? 0,
-        image: newLatest.image ?? "",
-      }));
-    }
-  };
-
   const handleLocationSelect = useCallback(
     (lat: number, lng: number) => {
       selectLocation({ lat, lng });
@@ -243,6 +223,24 @@ export default function SaunaMap() {
   const isCreating = mode === "creating:pick" || mode === "creating:form";
   const editingVisit = editingId ? visits.find((v) => v.id === editingId) ?? null : null;
   const historyEntries = editingVisit ? getVisitHistoryEntries(editingVisit) : [];
+
+  const handleDeleteLastHistory = () => {
+    if (!editingId) return;
+
+    removeLastHistoryEntry(editingId);
+
+    const newLatest = historyEntries[historyEntries.length - 2];
+
+    if (newLatest) {
+      setForm((prev) => ({
+        ...prev,
+        date: newLatest.date,
+        comment: newLatest.comment,
+        rating: newLatest.rating ?? 0,
+        image: newLatest.image ?? "",
+      }));
+    }
+  };
 
   if (!mounted) {
     return <div className="map-container" style={{ background: "var(--background)", height: "100%", width: "100%" }} />;


### PR DESCRIPTION
🎯 **What:** Extracted the deeply nested inline arrow function assigned to `onDeleteLastHistory` in `SaunaMap.tsx` into a named handler function called `handleDeleteLastHistory`.
💡 **Why:** The inline function at line 400 caused deep nesting within the JSX render block, which hurt readability and maintainability. Moving it to a named handler keeps the JSX clean and groups component logic with other event handlers (like `handleDelete`, `handleSubmit`).
✅ **Verification:** Ran `npm run lint` and `npx vitest run` to ensure no syntax, linting, or functional errors were introduced. Verified that the new handler continues to correctly access `editingId` from the component state and dynamically derives `historyEntries` from the `visits` array matching the behavior of the original closure. Ran `npm run build` to confirm a successful build.
✨ **Result:** Improved readability and structure of `SaunaMap.tsx` by flattening the JSX for the `VisitForm` component without altering any functionality.

---
*PR created automatically by Jules for task [2760096031702502881](https://jules.google.com/task/2760096031702502881) started by @handism*