### PR TITLE
🧹 Remove leftover console.debug in ServiceWorkerRegister

### DIFF
--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,7 +1,0 @@
-Title: "🧹 Remove leftover console.debug in ServiceWorkerRegister"
-
-Description:
-* 🎯 **What:** Removed the leftover `console.debug` and its containing `.then(...)` block in `ServiceWorkerRegister.tsx`.
-* 💡 **Why:** `console.debug` statements intended for debugging during development can clutter logs and reduce code cleanliness. Removing it improves readability and maintainability.
-* ✅ **Verification:** Re-ran `npm run lint` and `npx vitest run` to confirm that the existing test suite continues to pass without errors.
-* ✨ **Result:** The service worker registration maintains correct error handling and is more concise.

--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,0 +1,7 @@
+Title: "🧹 Remove leftover console.debug in ServiceWorkerRegister"
+
+Description:
+* 🎯 **What:** Removed the leftover `console.debug` and its containing `.then(...)` block in `ServiceWorkerRegister.tsx`.
+* 💡 **Why:** `console.debug` statements intended for debugging during development can clutter logs and reduce code cleanliness. Removing it improves readability and maintainability.
+* ✅ **Verification:** Re-ran `npm run lint` and `npx vitest run` to confirm that the existing test suite continues to pass without errors.
+* ✨ **Result:** The service worker registration maintains correct error handling and is more concise.

--- a/src/components/sauna-map/ServiceWorkerRegister.tsx
+++ b/src/components/sauna-map/ServiceWorkerRegister.tsx
@@ -10,14 +10,6 @@ export function ServiceWorkerRegister() {
         const swUrl = `${basePath}/sw.js`;
         navigator.serviceWorker
           .register(swUrl, { scope: `${basePath}/` })
-          .then((registration) => {
-            if (process.env.NODE_ENV !== "production") {
-              console.debug(
-                "ServiceWorker registration successful with scope: ",
-                registration.scope,
-              );
-            }
-          })
           .catch((err) => {
             console.warn("ServiceWorker registration failed: ", err);
           });


### PR DESCRIPTION
* 🎯 **What:** Removed the leftover `console.debug` and its containing `.then(...)` block in `ServiceWorkerRegister.tsx`.
* 💡 **Why:** `console.debug` statements intended for debugging during development can clutter logs and reduce code cleanliness. Removing it improves readability and maintainability.
* ✅ **Verification:** Re-ran `npm run lint` and `npx vitest run` to confirm that the existing test suite continues to pass without errors.
* ✨ **Result:** The service worker registration maintains correct error handling and is more concise.

---
*PR created automatically by Jules for task [8225138943128229146](https://jules.google.com/task/8225138943128229146) started by @handism*