### PR TITLE
🧪 Add TagCloudCard unit tests

### DIFF
--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,0 +1,12 @@
+# 🧪 Testing Improvement: Add unit tests for TagCloudCard
+
+## 🎯 What
+The `TagCloudCard` component, which renders the most frequently used sauna tags from visit history, lacked unit tests. This PR introduces comprehensive tests for the component.
+
+## 📊 Coverage
+- **Empty state handling:** Ensures the component renders `null` and nothing is output when no visits have valid tags.
+- **Correct counts & highlighting:** Verifies that tag links contain the correct `href`, display accurate counts, and apply the "popular tag" styling correctly (when counts meet the threshold `ceil(maxCount * 0.6)`).
+- **Status exclusion:** Confirms that visits marked as "wishlist" are properly ignored and only actual visited tags are processed.
+
+## ✨ Result
+Test coverage is improved for the stats UI, increasing our confidence against future regressions when modifying tag visualization logic or link routing.

--- a/src/app/stats/components/TagCloudCard.test.tsx
+++ b/src/app/stats/components/TagCloudCard.test.tsx
@@ -1,0 +1,76 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { expect, test, describe, afterEach } from "vitest";
+import { TagCloudCard } from "./TagCloudCard";
+import { SaunaVisit } from "@/components/sauna-map/types";
+
+describe("TagCloudCard", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const mockVisit = (
+    tags: string[],
+    status: "visited" | "wishlist" = "visited"
+  ): SaunaVisit => ({
+    id: Math.random().toString(),
+    name: "Test Sauna",
+    lat: 35,
+    lng: 139,
+    comment: "",
+    date: "2024-01-01",
+    tags,
+    status,
+  });
+
+  test("renders null when no visits have tags", () => {
+    const { container } = render(<TagCloudCard visits={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders tags with correct counts and popular styling", () => {
+    const visits = [
+      mockVisit(["ロウリュ", "水風呂", "外気浴"]),
+      mockVisit(["ロウリュ", "外気浴", "アメニティ"]),
+      mockVisit(["ロウリュ", "外気浴", "サ飯"]),
+      mockVisit(["ロウリュ", "外気浴", "コスパ"]),
+      mockVisit(["ロウリュ"]),
+      mockVisit(["外気浴"]),
+    ];
+    // ロウリュ: 5, 外気浴: 5, 水風呂: 1, アメニティ: 1, サ飯: 1, コスパ: 1
+    // maxCount = 5. threshold = ceil(5 * 0.6) = 3
+
+    render(<TagCloudCard visits={visits} />);
+
+    // Total 6 unique tags
+    expect(screen.getByText("全 6 種類")).toBeInTheDocument();
+
+    const roryuLink = screen.getByRole("link", { name: /#ロウリュ 5/ });
+    expect(roryuLink).toHaveAttribute(
+      "href",
+      "/?tag=%E3%83%AD%E3%82%A6%E3%83%AA%E3%83%A5"
+    );
+    expect(roryuLink.className).toMatch(/tagPillPopular/);
+
+    const mizuLink = screen.getByRole("link", { name: /#水風呂 1/ });
+    expect(mizuLink).toHaveAttribute(
+      "href",
+      "/?tag=%E6%B0%B4%E9%A2%A8%E5%91%82"
+    );
+    expect(mizuLink.className).not.toMatch(/tagPillPopular/);
+  });
+
+  test("excludes wishlist visits", () => {
+    const visits = [
+      mockVisit(["ロウリュ"], "visited"),
+      mockVisit(["ロウリュ", "アウフグース"], "wishlist"),
+    ];
+
+    render(<TagCloudCard visits={visits} />);
+    expect(screen.getByText("全 1 種類")).toBeInTheDocument();
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveTextContent("#ロウリュ 1");
+  });
+});


### PR DESCRIPTION
I've added unit tests for the `TagCloudCard` component, verifying its rendering under various conditions (empty state, happy path, popularity styling, and filtering out wishlist items). Tests were written using Vitest and React Testing Library, and passed successfully. No source code was modified, only tests were added.

---
*PR created automatically by Jules for task [11601302577660982780](https://jules.google.com/task/11601302577660982780) started by @handism*