### PR TITLE
🔒 [Security] Replace dangerouslySetInnerHTML with Next.js Script in layout

### DIFF
--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,0 +1,8 @@
+# Title: 🔒 [Security] Replace dangerouslySetInnerHTML with Next.js Script in layout
+
+## Description
+🎯 **What:** The vulnerability fixed is the use of `dangerouslySetInnerHTML` for injecting the initial theme script in `src/app/layout.tsx`. It has been replaced with Next.js's `<Script>` component using `strategy="beforeInteractive"`.
+
+⚠️ **Risk:** While the current implementation used a constant string without dynamic injection (meaning actual exploitability was zero), using `dangerouslySetInnerHTML` is generally considered an insecure pattern. If future changes inadvertently introduced user-controlled data into `THEME_INIT_SCRIPT`, it could have led to a Cross-Site Scripting (XSS) vulnerability.
+
+🛡️ **Solution:** By replacing `dangerouslySetInnerHTML` with `next/script` (`<Script id="theme-init" strategy="beforeInteractive">{THEME_INIT_SCRIPT}</Script>`), we eliminate the insecure pattern. The `beforeInteractive` strategy ensures the script is still injected and executed early (in the `<head>`), preserving the prevention of a dark-to-light theme flicker before initial rendering. This improves the security posture and hygiene of the codebase without altering functionality.

--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,8 +1,0 @@
-# Title: 🔒 [Security] Replace dangerouslySetInnerHTML with Next.js Script in layout
-
-## Description
-🎯 **What:** The vulnerability fixed is the use of `dangerouslySetInnerHTML` for injecting the initial theme script in `src/app/layout.tsx`. It has been replaced with Next.js's `<Script>` component using `strategy="beforeInteractive"`.
-
-⚠️ **Risk:** While the current implementation used a constant string without dynamic injection (meaning actual exploitability was zero), using `dangerouslySetInnerHTML` is generally considered an insecure pattern. If future changes inadvertently introduced user-controlled data into `THEME_INIT_SCRIPT`, it could have led to a Cross-Site Scripting (XSS) vulnerability.
-
-🛡️ **Solution:** By replacing `dangerouslySetInnerHTML` with `next/script` (`<Script id="theme-init" strategy="beforeInteractive">{THEME_INIT_SCRIPT}</Script>`), we eliminate the insecure pattern. The `beforeInteractive` strategy ensures the script is still injected and executed early (in the `<head>`), preserving the prevention of a dark-to-light theme flicker before initial rendering. This improves the security posture and hygiene of the codebase without altering functionality.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Outfit } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 
 // base.css の --font-main が参照するフォント。
@@ -55,7 +56,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <head>
-        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
+        <Script id="theme-init" strategy="beforeInteractive">{THEME_INIT_SCRIPT}</Script>
       </head>
       <body className={outfit.variable}>{children}</body>
     </html>


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the use of `dangerouslySetInnerHTML` for injecting the initial theme script in `src/app/layout.tsx`. It has been replaced with Next.js's `<Script>` component using `strategy="beforeInteractive"`.

⚠️ **Risk:** While the current implementation used a constant string without dynamic injection (meaning actual exploitability was zero), using `dangerouslySetInnerHTML` is generally considered an insecure pattern. If future changes inadvertently introduced user-controlled data into `THEME_INIT_SCRIPT`, it could have led to a Cross-Site Scripting (XSS) vulnerability.

🛡️ **Solution:** By replacing `dangerouslySetInnerHTML` with `next/script` (`<Script id="theme-init" strategy="beforeInteractive">{THEME_INIT_SCRIPT}</Script>`), we eliminate the insecure pattern. The `beforeInteractive` strategy ensures the script is still injected and executed early (in the `<head>`), preserving the prevention of a dark-to-light theme flicker before initial rendering. This improves the security posture and hygiene of the codebase without altering functionality.

---
*PR created automatically by Jules for task [3180698615602449189](https://jules.google.com/task/3180698615602449189) started by @handism*