### PR TITLE
🧪 [Testing Improvement] Add tests for saveTheme in theme.ts

### DIFF
--- a/src/components/sauna-map/utils/theme.test.ts
+++ b/src/components/sauna-map/utils/theme.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { getInitialTheme } from "./theme";
+import { getInitialTheme, saveTheme } from "./theme";
+import * as storage from "./storage";
 import { THEME_STORAGE_KEY } from "./constants";
 
 describe("getInitialTheme", () => {
@@ -66,5 +67,19 @@ describe("getInitialTheme", () => {
       `Failed to read "${THEME_STORAGE_KEY}" from localStorage:`,
       expect.any(Error),
     );
+  });
+});
+
+describe("saveTheme", () => {
+  it("should call writeStorage with THEME_STORAGE_KEY and the provided theme", () => {
+    const writeStorageSpy = vi.spyOn(storage, "writeStorage").mockImplementation(() => true);
+
+    saveTheme("light");
+    expect(writeStorageSpy).toHaveBeenCalledWith(THEME_STORAGE_KEY, "light");
+
+    saveTheme("dark");
+    expect(writeStorageSpy).toHaveBeenCalledWith(THEME_STORAGE_KEY, "dark");
+
+    writeStorageSpy.mockRestore();
   });
 });


### PR DESCRIPTION
🎯 **What:** The `saveTheme` function in `src/components/sauna-map/utils/theme.ts` was previously untested. This PR adds unit tests to verify its behavior.
📊 **Coverage:** The new test suite covers the happy path by verifying that `saveTheme` correctly calls the underlying `writeStorage` utility with the `THEME_STORAGE_KEY` and the correct theme ("light" or "dark").
✨ **Result:** Test coverage for `src/components/sauna-map/utils/theme.ts` is improved, ensuring regressions are caught if the theme-saving logic changes in the future.

---
*PR created automatically by Jules for task [7128662940921612262](https://jules.google.com/task/7128662940921612262) started by @handism*