### PR TITLE
🧪 MonthlyVisitsChart tests

### DIFF
--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,0 +1,5 @@
+# 🧪 MonthlyVisitsChart Tests
+
+**What:** Added missing tests for the `MonthlyVisitsChart` component.
+**Coverage:** Added coverage for empty state rendering and calculation of amount of entries.
+**Result:** The component is now fully tested and prevents regressions.

--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,5 +1,0 @@
-# 🧪 MonthlyVisitsChart Tests
-
-**What:** Added missing tests for the `MonthlyVisitsChart` component.
-**Coverage:** Added coverage for empty state rendering and calculation of amount of entries.
-**Result:** The component is now fully tested and prevents regressions.

--- a/src/components/charts/MonthlyVisitsChart.test.tsx
+++ b/src/components/charts/MonthlyVisitsChart.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import MonthlyVisitsChart from './MonthlyVisitsChart';
+import { ChartTheme } from './chartTheme';
+import { FlatVisitHistoryEntry } from '@/components/sauna-map/utils/visitHistory';
+
+vi.mock('recharts', async () => {
+  const ActualRecharts = await vi.importActual<typeof import('recharts')>('recharts');
+  return {
+    ...ActualRecharts,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="responsive-container" style={{ width: '100%', height: 260 }}>
+        {children}
+      </div>
+    )
+  };
+});
+
+describe('MonthlyVisitsChart', () => {
+  const mockTheme: ChartTheme = 'light';
+
+  const mockEntries = [
+    { visitId: '1', date: '2023-01-15', status: 'visited', comment: '', id: 'a', name: 'a', lat: 1, lng: 1 },
+    { visitId: '2', date: '2023-01-20', status: 'visited', comment: '', id: 'a', name: 'a', lat: 1, lng: 1 },
+    { visitId: '3', date: '2023-02-05', status: 'visited', comment: '', id: 'a', name: 'a', lat: 1, lng: 1 },
+    { visitId: '4', date: '2024-01-10', status: 'visited', comment: '', id: 'a', name: 'a', lat: 1, lng: 1 },
+  ] as FlatVisitHistoryEntry[];
+
+  it('renders empty state when no entries are provided', () => {
+    render(<MonthlyVisitsChart entries={[]} theme={mockTheme} />);
+    expect(screen.getByText(/訪問記録がありません/i)).toBeInTheDocument();
+  });
+
+  it('calculates correctly the amount of entries per month and renders year boundaries', () => {
+    render(<MonthlyVisitsChart entries={mockEntries} theme={mockTheme} />);
+    const chart = screen.getByRole('img', { name: /月別訪問数の棒グラフ/ });
+    expect(chart).toBeInTheDocument();
+
+    expect(chart.getAttribute('aria-label')).toContain('2023-01から2024-01まで');
+    expect(chart.getAttribute('aria-label')).toContain('合計4件の訪問');
+  });
+});

--- a/src/components/charts/MonthlyVisitsChart.test.tsx
+++ b/src/components/charts/MonthlyVisitsChart.test.tsx
@@ -1,43 +1,64 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import MonthlyVisitsChart from './MonthlyVisitsChart';
-import { ChartTheme } from './chartTheme';
 import { FlatVisitHistoryEntry } from '@/components/sauna-map/utils/visitHistory';
 
-vi.mock('recharts', async () => {
-  const ActualRecharts = await vi.importActual<typeof import('recharts')>('recharts');
+vi.mock('recharts', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('recharts')>();
   return {
-    ...ActualRecharts,
+    ...mod,
     ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
       <div data-testid="responsive-container" style={{ width: '100%', height: 260 }}>
         {children}
       </div>
-    )
+    ),
   };
 });
 
 describe('MonthlyVisitsChart', () => {
-  const mockTheme: ChartTheme = 'light';
+  afterEach(() => {
+    cleanup();
+  });
 
-  const mockEntries = [
-    { visitId: '1', date: '2023-01-15', status: 'visited', comment: '', id: 'a', name: 'a', lat: 1, lng: 1 },
-    { visitId: '2', date: '2023-01-20', status: 'visited', comment: '', id: 'a', name: 'a', lat: 1, lng: 1 },
-    { visitId: '3', date: '2023-02-05', status: 'visited', comment: '', id: 'a', name: 'a', lat: 1, lng: 1 },
-    { visitId: '4', date: '2024-01-10', status: 'visited', comment: '', id: 'a', name: 'a', lat: 1, lng: 1 },
-  ] as FlatVisitHistoryEntry[];
+  const mockEntries: FlatVisitHistoryEntry[] = [
+    { visitId: '1', date: '2023-01-15', status: 'visited', comment: '' },
+    { visitId: '2', date: '2023-01-20', status: 'visited', comment: '' },
+    { visitId: '3', date: '2023-02-05', status: 'visited', comment: '' },
+    { visitId: '4', date: '2024-01-10', status: 'visited', comment: '' },
+  ];
 
   it('renders empty state when no entries are provided', () => {
-    render(<MonthlyVisitsChart entries={[]} theme={mockTheme} />);
+    render(<MonthlyVisitsChart entries={[]} theme="light" />);
     expect(screen.getByText(/訪問記録がありません/i)).toBeInTheDocument();
   });
 
   it('calculates correctly the amount of entries per month and renders year boundaries', () => {
-    render(<MonthlyVisitsChart entries={mockEntries} theme={mockTheme} />);
+    render(<MonthlyVisitsChart entries={mockEntries} theme="light" />);
     const chart = screen.getByRole('img', { name: /月別訪問数の棒グラフ/ });
     expect(chart).toBeInTheDocument();
 
     expect(chart.getAttribute('aria-label')).toContain('2023-01から2024-01まで');
     expect(chart.getAttribute('aria-label')).toContain('合計4件の訪問');
   });
+
+  it('renders correctly with single year entries', () => {
+    const singleYearEntries: FlatVisitHistoryEntry[] = [
+      { visitId: '1', date: '2023-01-15', status: 'visited', comment: '' },
+      { visitId: '2', date: '2023-03-20', status: 'visited', comment: '' },
+    ];
+
+    render(<MonthlyVisitsChart entries={singleYearEntries} theme="light" />);
+    const chart = screen.getByRole('img', { name: /月別訪問数の棒グラフ/ });
+    expect(chart).toBeInTheDocument();
+    expect(chart.getAttribute('aria-label')).toContain('2023-01から2023-03まで');
+    expect(chart.getAttribute('aria-label')).toContain('合計2件の訪問');
+  });
+
+  it('renders correctly in dark theme', () => {
+    render(<MonthlyVisitsChart entries={mockEntries} theme="dark" />);
+    const chart = screen.getByRole('img', { name: /月別訪問数の棒グラフ/ });
+    expect(chart).toBeInTheDocument();
+  });
 });
+


### PR DESCRIPTION
Added testing coverage for `MonthlyVisitsChart` component, testing rendering for empty entries arrays and validation of processed entry counting and boundaries.

---
*PR created automatically by Jules for task [13314879865219139303](https://jules.google.com/task/13314879865219139303) started by @handism*