### PR TITLE
Refactor array joins to template literals

### DIFF
--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,0 +1,8 @@
+# PR Proposal: Refactor array joins to template literals
+
+## Description
+This PR refactors array `.join()` calls to template literals for performance improvements in `geocoding.ts`.
+It avoids unnecessary array allocations and correctly uses the nullish coalescing operator (`??`) to handle optional fields securely without stringifying `undefined` values.
+
+## Changes
+- **`src/components/sauna-map/utils/geocoding.ts`**: Converted `formatJapaneseAddress` to use template literals with `??`.

--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,8 +1,0 @@
-# PR Proposal: Refactor array joins to template literals
-
-## Description
-This PR refactors array `.join()` calls to template literals for performance improvements in `geocoding.ts`.
-It avoids unnecessary array allocations and correctly uses the nullish coalescing operator (`??`) to handle optional fields securely without stringifying `undefined` values.
-
-## Changes
-- **`src/components/sauna-map/utils/geocoding.ts`**: Converted `formatJapaneseAddress` to use template literals with `??`.

--- a/src/components/sauna-map/utils/geocoding.ts
+++ b/src/components/sauna-map/utils/geocoding.ts
@@ -37,14 +37,12 @@ interface NominatimRawResult {
  */
 function formatJapaneseAddress(address?: NominatimRawAddress): string {
   if (!address) return "";
-  const parts = [
-    address.state || address.province || "",
-    address.city || address.town || address.village || "",
-    address.suburb || address.city_district || address.quarter || address.neighbourhood || "",
-    address.road || "",
-    address.house_number || "",
-  ];
-  return parts.filter(Boolean).join("");
+  const state = address.state ?? address.province ?? "";
+  const city = address.city ?? address.town ?? address.village ?? "";
+  const suburb = address.suburb ?? address.city_district ?? address.quarter ?? address.neighbourhood ?? "";
+  const road = address.road ?? "";
+  const house_number = address.house_number ?? "";
+  return `${state}${city}${suburb}${road}${house_number}`;
 }
 
 /**


### PR DESCRIPTION
This PR refactors array `.join()` calls to template literals for performance improvements in `geocoding.ts`. 
It avoids unnecessary array allocations and correctly uses the nullish coalescing operator (`??`) to handle optional fields securely without stringifying `undefined` values.

---
*PR created automatically by Jules for task [4494342719779342862](https://jules.google.com/task/4494342719779342862) started by @handism*