### PR TITLE
chore(deps): Node.js を 22 から 24 (LTS) へ更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - uses: actions/configure-pages@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM node:22-bookworm-slim AS frontend
+FROM node:24-bookworm-slim AS frontend
 WORKDIR /app
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ docker-compose.yaml  frontend／api／PostgreSQL 17
 
 ## フロントエンド開発
 
-Node.js 22を使用します。npmコマンドは `frontend/` ディレクトリで実行します。
+Node.js 24 (LTS) を使用します。npmコマンドは `frontend/` ディレクトリで実行します。
 
 ```bash
 cd frontend

--- a/frontend/Dockerfile.frontend.dev
+++ b/frontend/Dockerfile.frontend.dev
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim
+FROM node:24-bookworm-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## 概要

Dependabot の #94 / #96 は Node 25 への更新を提案していましたが、Node 25 は奇数系の Current ラインで [公式リリーススケジュール](https://github.com/nodejs/Release) 上 **2026-06-01 に EOL 済み**です。サポート切れバージョンへの移行は後退となるため両 PR はクローズし、代わりに LTS の **Node 24**（EOL 2028-04-30）へ更新します。

## 変更内容

Dockerfile だけを更新すると CI やビルド環境とバージョンがずれるため、Node のバージョンを参照している箇所をすべて揃えました。

| ファイル | 変更 |
| --- | --- |
| `Dockerfile` | `node:22-bookworm-slim` → `node:24-bookworm-slim` |
| `frontend/Dockerfile.frontend.dev` | 同上 |
| `.github/workflows/ci.yml` | `node-version: 22` → `24` |
| `.github/workflows/pages.yml` | `node-version: 22` → `24` |
| `README.md` | 開発環境の記載を Node.js 24 (LTS) へ更新 |

## 検証

`frontend/` にて以下を実行し、すべてパスすることを確認しました。

- `npm run lint`
- `npm run typecheck`
- `npm run test`（72 ファイル / 485 テスト パス）
- `npm run build:local`
- `npm run build:api`

本番イメージのビルドと `GET /up` のスモークテストは CI の infrastructure ジョブで確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)