### PR TITLE
🧪 Add tests for JSON parsing errors in visitHistory.ts

### DIFF
--- a/frontend/src/components/sauna-map/utils/visitHistory.test.ts
+++ b/frontend/src/components/sauna-map/utils/visitHistory.test.ts
@@ -391,6 +391,28 @@ describe("getInitialVisits", () => {
     );
   });
 
+  it("should catch JSON.parse errors, log error and return baseVisits", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    store["sauna-itta_visits"] = "{ invalid_json }";
+
+    const visits = getInitialVisits();
+    expect(Array.isArray(visits)).toBe(true);
+    expect(visits.length).toBeGreaterThan(0);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to parse saved visits:",
+      expect.any(Error)
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should return baseVisits if parsed saved data is not an array", () => {
+    store["sauna-itta_visits"] = JSON.stringify({ not: "an array" });
+
+    const visits = getInitialVisits();
+    expect(Array.isArray(visits)).toBe(true);
+    expect(visits.length).toBeGreaterThan(0);
+  });
+
   it("保存がまだ無い場合は同梱JSONを返すこと", () => {
     const visits = getInitialVisits();
 


### PR DESCRIPTION
This PR addresses a gap in the test suite for `frontend/src/components/sauna-map/utils/visitHistory.ts`, specifically around the error handling logic during `getInitialVisits()` when reading from `localStorage`. The function falls back to a base set of visits if `JSON.parse` fails or if the parsed content is not an array, but these branches were not previously tested.

Two new test cases have been added to `getInitialVisits`:
- Testing the `catch` block by providing invalid JSON (e.g., `"{ invalid_json }"`). This verifies that `console.error` is called correctly and the function gracefully returns `baseVisits`.
- Testing the array validation block (`if (!Array.isArray(parsedSaved))`) by providing valid JSON that parses to an object instead of an array. This verifies the function returns `baseVisits`.

Improved test coverage for `visitHistory.ts` by explicitly validating the error recovery pathways for local storage retrieval.

---
*PR created automatically by Jules for task [15640757379102291044](https://jules.google.com/task/15640757379102291044) started by @handism*