### PR TITLE
🧪 Add error path tests for useVisitImportExport

### DIFF
--- a/frontend/src/components/sauna-map/hooks/useVisitImportExport.test.ts
+++ b/frontend/src/components/sauna-map/hooks/useVisitImportExport.test.ts
@@ -260,4 +260,48 @@ describe("useVisitImportExport", () => {
       "error",
     );
   });
+
+  test("保存に失敗した場合はエラートーストを表示する", async () => {
+    const saveVisitsMockFail = vi.fn().mockReturnValue(false);
+    const showToast = vi.fn();
+    const { result } = renderHook(() => useVisitImportExport(mockVisits, saveVisitsMockFail, showToast));
+
+    const newVisit = { id: "2", name: "Sauna B", lat: 35.1, lng: 139.1, comment: "nice", date: "2023-01-02" };
+    const file = new File([JSON.stringify([newVisit])], "test.json", { type: "application/json" });
+    const input = document.createElement("input");
+    Object.defineProperty(input, "files", { value: [file] });
+
+    await act(async () => {
+      await result.current.handleImportData({ target: input } as ChangeEvent<HTMLInputElement>);
+    });
+
+    expect(showToast).toHaveBeenCalledWith(
+      "画像サイズが大きすぎるため保存に失敗しました。画像を小さくして再度お試しください。",
+      "error",
+    );
+    expect(showToast).toHaveBeenCalledTimes(1);
+  });
+
+  test("JSONの読み込みに失敗した場合はエラートーストを表示する", async () => {
+    const showToast = vi.fn();
+    const { result } = renderHook(() => useVisitImportExport(mockVisits, saveVisitsMock, showToast));
+
+    const file = new File(["invalid json"], "test.json", { type: "application/json" });
+    const input = document.createElement("input");
+    Object.defineProperty(input, "files", { value: [file] });
+
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await act(async () => {
+      await result.current.handleImportData({ target: input } as ChangeEvent<HTMLInputElement>);
+    });
+
+    expect(showToast).toHaveBeenCalledWith(
+      "JSONの読み込みに失敗しました。ファイル形式を確認してください。",
+      "error",
+    );
+    expect(showToast).toHaveBeenCalledTimes(1);
+
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,0 +1,7 @@
+## Title
+🧪 Add error path tests for useVisitImportExport
+
+## Description
+🎯 **What:** This PR addresses the testing gap in `useVisitImportExport.ts` by adding missing tests for error paths during file import.
+📊 **Coverage:** The new tests cover scenarios where `saveVisits` returns false (failed save) and when parsing the JSON fails, asserting the correct error messages are shown via toast.
+✨ **Result:** Test coverage is improved for the edge cases ensuring that error handling logic behaves as expected.


### PR DESCRIPTION
This PR addresses the testing gap in `useVisitImportExport.ts` by adding missing tests for error paths during file import.
The new tests cover scenarios where `saveVisits` returns false (failed save) and when parsing the JSON fails, asserting the correct error messages are shown via toast.
Test coverage is improved for the edge cases ensuring that error handling logic behaves as expected.

---
*PR created automatically by Jules for task [5863749523255410514](https://jules.google.com/task/5863749523255410514) started by @handism*