### PR TITLE
🧪 [Testing] Add error path test for useSaunaVisits mutation wrapper

### DIFF
--- a/frontend/src/components/sauna-map/hooks/useSaunaVisits.test.ts
+++ b/frontend/src/components/sauna-map/hooks/useSaunaVisits.test.ts
@@ -97,4 +97,25 @@ describe("useSaunaVisits", () => {
     expect(result.current.loadError).toBe("Initial Load Error");
     expect(result.current.visits).toEqual([]); // since we default to empty array
   });
+
+  it("409以外のエラー時はメッセージをトーストで伝え、状態を変更しない", async () => {
+    const showToast = vi.fn();
+    const source = repository({
+      create: vi.fn().mockRejectedValue(new Error("ネットワークエラー")),
+    });
+    const { result } = renderHook(() => useSaunaVisits(showToast, source));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let addResult;
+    await act(async () => {
+      addResult = await result.current.addVisit({ lat: 35, lng: 139 }, {
+        name: "新規", comment: "", image: "", date: "2026-08-02", rating: 4,
+        tagsText: "", status: "visited", area: "東京", appendHistory: false,
+      });
+    });
+
+    expect(result.current.visits).toEqual(initialVisits);
+    expect(showToast).toHaveBeenCalledWith("ネットワークエラー", "error");
+    expect(addResult).toEqual({ success: false, newVisit: undefined });
+  });
 });


### PR DESCRIPTION
This PR adds a missing test case for the error path in the `useSaunaVisits` hook. It addresses the gap where the generic error handling within the `runMutation` wrapper was not covered by automated tests.

The new test case specifically covers the scenario where a generic mutation (e.g., `addVisit` utilizing `repository.create`) throws a standard `Error`. It verifies that:
- The `catch` block inside `runMutation` is correctly executed.
- The user is notified via `showToast` with the error message.
- The mutation properly returns `{ success: false }`.
- The application state (e.g., the `visits` array) remains unchanged.

Test coverage for `frontend/src/components/sauna-map/hooks/useSaunaVisits.ts` has been improved, and the reliability of the mutation error handling is now automatically verified by the test suite. No new functionality was altered in the production code; only the test suite was updated.

---
*PR created automatically by Jules for task [1870190620095062344](https://jules.google.com/task/1870190620095062344) started by @handism*