### PR TITLE
docs: Gemfile更新時のbundleボリューム反映手順を追記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,5 +60,5 @@
 ## 開発環境
 
 - リポジトリは`frontend/`（Next.js）／`backend/`（Rails）／`infra/`（Terraform）のモノレポ構成です。ルートには`Dockerfile`、`docker-compose.yaml`、`README.md`等のリポジトリ横断ファイルだけを置きます。
-- 本番イメージはルート`Dockerfile`（ビルドコンテキストはリポジトリルート）でAPIモードのNext.js静的成果物とRailsだけを組み込み、非rootでPumaを起動します。ローカルは`frontend`／`api`／`postgres`のDocker Composeを使用します。フロント依存関係は`frontend/Dockerfile.frontend.dev`のビルド時に`npm ci`でインストールします（ビルドコンテキストは`./frontend`）。APIは起動時に`/app/tmp/pids/server.pid`を除去し、`bin/rails db:prepare`の成功後にRailsを`exec`起動します。依存関係変更時は`docker-compose up --build`でフロントイメージを再ビルドしてください。
+- 本番イメージはルート`Dockerfile`（ビルドコンテキストはリポジトリルート）でAPIモードのNext.js静的成果物とRailsだけを組み込み、非rootでPumaを起動します。ローカルは`frontend`／`api`／`postgres`のDocker Composeを使用します。フロント依存関係は`frontend/Dockerfile.frontend.dev`のビルド時に`npm ci`でインストールします（ビルドコンテキストは`./frontend`）。APIは起動時に`/app/tmp/pids/server.pid`を除去し、`bin/rails db:prepare`の成功後にRailsを`exec`起動します。依存関係変更時は`docker-compose up --build`でフロントイメージを再ビルドしてください。APIのgemは名前付きボリューム`backend_bundle`が`/usr/local/bundle`を覆うため`--build`では更新されません。`Gemfile`変更時は`docker compose run --rm --no-deps api bundle install`でボリューム側へ反映します（`docker compose down -v`は`postgres_data`まで削除するため使わないこと）。
 - CIの本番イメージ検証はビルドだけで終えず、PostgreSQLへ`db:prepare`したうえでproductionコンテナを起動し、`GET /up`が成功するところまで確認します。スモークテストでは外部GCSへ接続しないよう`ACTIVE_STORAGE_SERVICE=local`を指定します。

--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ docker compose up --build
 
 フロントの依存関係は `frontend/Dockerfile.frontend.dev` のビルド時に `npm ci` でインストールされます。APIは前回の異常終了で残ったRailsのPIDファイルを除去し、`bin/rails db:prepare` を実行してから起動します。`package.json` または `package-lock.json` を更新した場合も、フロントイメージへ依存関係を反映するため再度 `docker-compose up --build` を実行してください。
 
+### Gemfileを更新したとき
+
+APIのgemは名前付きボリューム `backend_bundle` を `/usr/local/bundle` へマウントして保持します。名前付きボリュームは空のときだけイメージの中身で初期化されるため、`Gemfile` や `Gemfile.lock` を更新しても**`--build` では反映されません**。イメージのビルドは成功するのに起動時だけ `Bundler::GemNotFound` で落ちる場合はこれが原因です。次のコマンドでボリューム側へ反映してください。
+
+```bash
+docker compose run --rm --no-deps api bundle install --jobs 4 --retry 3
+```
+
+`docker volume rm sauna-itta_backend_bundle` してから `docker compose up` でも、ボリュームが再作成されるため解消します。ただし `docker compose down -v` は `postgres_data` も削除してローカルの開発用DBが失われるため使わないでください。
+
 - フロント: `http://localhost:3000`
 - Rails: `http://localhost:3001`
 - 開発ログイン: `ENABLE_DEV_LOGIN=true` の場合だけ `POST http://localhost:3000/dev/login`


### PR DESCRIPTION
## 背景

Rails を 8.1.3.1 へ更新（#97）したあと、ローカルで `docker compose up --build` が成功するにもかかわらず、API コンテナだけが起動時に落ちる事象が発生しました。

```
Could not find rails-8.1.3.1, ... in locally installed gems (Bundler::GemNotFound)
```

原因は、`backend/Dockerfile.dev` が gem を入れる `/usr/local/bundle` を、`docker-compose.yaml` の名前付きボリューム `backend_bundle` が覆っていることです。名前付きボリュームは空のときだけイメージの内容で初期化されるため、既存のボリュームが古い gem を保持し続け、イメージ側の更新が見えなくなっていました。

実際に中身を比較すると差がはっきり出ます。

| | rails |
| --- | --- |
| イメージ内 | 8.1.3.1 |
| ボリューム内 | 8.1.3 |

**ビルドは毎回成功するのに実行時だけ落ちる**ため原因が分かりにくく、`--build` を繰り返しても解消しません。ハマりどころなので手順を明文化します。

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `README.md` | 「Gemfileを更新したとき」の項を追加し、`docker compose run --rm --no-deps api bundle install` を案内 |
| `AGENTS.md` | 開発環境の節に同趣旨を1文追記（`CLAUDE.md` はシンボリックリンクのため自動で追随） |

あわせて `docker compose down -v` が `postgres_data` も削除しローカル開発用 DB が失われる点を注意として記載しました。

## 検証

ドキュメントのみの変更のためテストは実行していません。記載したコマンドは実際に実行し、API コンテナが healthy になり `GET /up` が 200 を返すことを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)