### PR TITLE
🧪 [Testing] Add error path test for initial load in useSaunaVisits hook

### DIFF
--- a/frontend/src/components/sauna-map/hooks/useSaunaVisits.test.ts
+++ b/frontend/src/components/sauna-map/hooks/useSaunaVisits.test.ts
@@ -68,4 +68,14 @@ describe("useSaunaVisits", () => {
     expect(result.current.visits).toEqual(initialVisits);
     expect(showToast).toHaveBeenCalledWith(expect.stringContaining("再読み込み"), "error");
   });
+
+  it("初期読み込み時のエラーを適切に処理しloadErrorに設定する", async () => {
+    const source = repository({
+      list: vi.fn().mockRejectedValue(new Error("ネットワークエラー")),
+    });
+    const { result } = renderHook(() => useSaunaVisits(undefined, source));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.loadError).toBe("ネットワークエラー");
+  });
 });

--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,0 +1,13 @@
+# 🧪 [Testing] Add error path test for initial load in useSaunaVisits hook
+
+## 🎯 **What**
+This PR addresses a missing test case in `useSaunaVisits.test.ts` where the initial data load in the `useEffect` hook throws an error. Previously, there was no test confirming that `loadError` state gets correctly set when `repository.list()` fails during the mount phase.
+
+## 📊 **Coverage**
+- Added a specific test case that mocks `repository.list()` to reject with an error (e.g. "ネットワークエラー").
+- Verified that the `catch` block correctly transitions `loadError` from `null` to the expected error message.
+- Tested that the component safely resolves its `loading` state to `false` even if an error is thrown.
+
+## ✨ **Result**
+- Test coverage for the `useSaunaVisits` hook is improved, effectively ensuring that the `loadError` logic for the critical initial loading path functions correctly and does not break during future refactoring.
+- The hook is now robustly tested against network or parsing failures during initial hydration.


### PR DESCRIPTION
# 🧪 [Testing] Add error path test for initial load in useSaunaVisits hook

## 🎯 **What**
This PR addresses a missing test case in `useSaunaVisits.test.ts` where the initial data load in the `useEffect` hook throws an error. Previously, there was no test confirming that `loadError` state gets correctly set when `repository.list()` fails during the mount phase.

## 📊 **Coverage**
- Added a specific test case that mocks `repository.list()` to reject with an error (e.g. "ネットワークエラー").
- Verified that the `catch` block correctly transitions `loadError` from `null` to the expected error message.
- Tested that the component safely resolves its `loading` state to `false` even if an error is thrown.

## ✨ **Result**
- Test coverage for the `useSaunaVisits` hook is improved, effectively ensuring that the `loadError` logic for the critical initial loading path functions correctly and does not break during future refactoring.
- The hook is now robustly tested against network or parsing failures during initial hydration.

---
*PR created automatically by Jules for task [8267571935832045110](https://jules.google.com/task/8267571935832045110) started by @handism*