### PR TITLE
🧪 [Testing] Add missing error path test for image upload in useVisitForm

### DIFF
--- a/frontend/src/components/sauna-map/hooks/useVisitForm.test.ts
+++ b/frontend/src/components/sauna-map/hooks/useVisitForm.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useVisitForm, UseVisitFormOptions } from "./useVisitForm";
 import { SaunaVisit } from "../types";
+import * as utils from "../utils";
 
 describe("useVisitForm", () => {
   const mockVisit: SaunaVisit = {
@@ -162,5 +163,23 @@ describe("useVisitForm", () => {
 
     expect(options.showToast).toHaveBeenCalledWith("サウナの場所が選択されていません。", "error");
     expect(options.addVisit).not.toHaveBeenCalled();
+  });
+
+  it("handleImageFile で画像圧縮に失敗したときにエラーのトーストが表示されること", async () => {
+    const { result } = renderHook(() => useVisitForm(defaultOptions));
+
+    const spy = vi.spyOn(utils, "compressAndGetBase64").mockRejectedValue(new Error("compression failed"));
+
+    await act(async () => {
+      await result.current.handleImageFile(new File([""], "test.png"));
+    });
+
+    // 実装が本当にモックを経由したことまで確かめないと、jsdom で実処理が失敗しても
+    // 同じトーストが出るため、このテストは素通りしてしまう。
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(defaultOptions.showToast).toHaveBeenCalledWith("画像の圧縮に失敗しました。別の画像で試してください。", "error");
+    expect(result.current.imageUploading).toBe(false);
+
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
This PR addresses a missing test gap for the error path in `useVisitForm.ts`. Specifically, it covers the scenario where the image compression utility (`compressAndGetBase64`) fails and throws an error during the `handleImageFile` execution.

Coverage details:
- Adds a new test case checking that when image compression fails, an error toast is appropriately displayed.
- The test spies on the exported `compressAndGetBase64` utility and mimics failure gracefully.
- Successfully restores test suite coverage state avoiding environmental leakage.

---
*PR created automatically by Jules for task [14712797112282450292](https://jules.google.com/task/14712797112282450292) started by @handism*