### PR TITLE
🧪 Add missing error path test in useVisitImportExport

### DIFF
--- a/frontend/src/components/sauna-map/hooks/useVisitImportExport.test.ts
+++ b/frontend/src/components/sauna-map/hooks/useVisitImportExport.test.ts
@@ -260,4 +260,42 @@ describe("useVisitImportExport", () => {
       "error",
     );
   });
+
+  test("APIインポートが途中で失敗し、さらに再読み込みにも失敗した場合エラーログを出力する", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const importBatch = vi.fn()
+      .mockRejectedValueOnce(new Error("サーバーへ接続できません。"));
+    const reloadError = new Error("再読み込みエラー");
+    const reload = vi.fn().mockRejectedValue(reloadError);
+    const showToast = vi.fn();
+    const { result } = renderHook(() =>
+      useVisitImportExport(mockVisits, undefined, showToast, importBatch, reload),
+    );
+    const imported = Array.from({ length: 5 }, (_, index) => ({
+      id: `fail-${index}`,
+      name: `Sauna ${index}`,
+      lat: 35,
+      lng: 139,
+      comment: "",
+      date: "2026-08-02",
+    }));
+    const file = new File([JSON.stringify(imported)], "test.json", { type: "application/json" });
+    const input = document.createElement("input");
+    Object.defineProperty(input, "files", { value: [file] });
+
+    await act(async () => {
+      await result.current.handleImportData({ target: input } as ChangeEvent<HTMLInputElement>);
+    });
+
+    expect(reload).toHaveBeenCalledOnce();
+    expect(consoleSpy).toHaveBeenCalledWith("インポート失敗後の再読み込みにも失敗しました。", reloadError);
+
+    // Toast のエラーも確認
+    expect(showToast).toHaveBeenCalledWith(
+      "データの取り込みに失敗しました。サーバーへ接続できません。",
+      "error"
+    );
+
+    consoleSpy.mockRestore();
+  });
 });

--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,0 +1,15 @@
+# 🧪 [testing improvement] Add missing error path test in useVisitImportExport
+
+## 🎯 **What**
+This PR addresses a testing gap in `useVisitImportExport.ts` by adding a test case to cover the scenario where both the data import batch process and the subsequent reload mechanism fail. Previously, the error logging behavior ("インポート失敗後の再読み込みにも失敗しました。") and error object thrown were not tested.
+
+## 📊 **Coverage**
+The new test case verifies:
+- `importBatch` throwing an error simulates an API import failure.
+- A subsequent failure in `reload` correctly triggers the nested `catch` block.
+- `console.error` is called with the exact message "インポート失敗後の再読み込みにも失敗しました。" along with the mocked error.
+- A failure toast is displayed correctly informing the user about the connection error.
+- Ensures robust testing by safely spying on `console.error` and restoring it after execution.
+
+## ✨ **Result**
+Increased the test coverage in `useVisitImportExport.ts` and enhanced the overall reliability of the codebase by verifying that unexpected catastrophic failures during data imports are logged and handled as expected. The test suite is now stronger in catching potential regressions.


### PR DESCRIPTION
This PR adds a missing test case in `useVisitImportExport.test.ts` to ensure full coverage of the error paths. Specifically, it tests the scenario where an API import batch failure triggers a reload, which also fails. The test correctly mocks the failures, verifies that `console.error` logs the expected message and error object, and ensures the UI properly displays a failure toast.

---
*PR created automatically by Jules for task [10682599030797641768](https://jules.google.com/task/10682599030797641768) started by @handism*