### PR TITLE
🧪 Add Error Path Test for Service Worker Registration

### DIFF
--- a/frontend/src/components/sauna-map/ServiceWorkerRegister.test.tsx
+++ b/frontend/src/components/sauna-map/ServiceWorkerRegister.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, cleanup } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ServiceWorkerRegister } from "./ServiceWorkerRegister";
 
@@ -14,6 +14,7 @@ describe("ServiceWorkerRegister", () => {
       value: originalNavigator,
       writable: true,
     });
+    cleanup();
   });
 
   it("renders null without throwing errors", () => {
@@ -39,5 +40,32 @@ describe("ServiceWorkerRegister", () => {
     window.dispatchEvent(new Event("load"));
 
     expect(registerMock).toHaveBeenCalledWith("/sauna-itta/sw.js", { scope: "/sauna-itta/" });
+  });
+
+  it("logs a warning when service worker registration fails", async () => {
+    const error = new Error("Registration failed");
+    const registerMock = vi.fn().mockRejectedValue(error);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    Object.defineProperty(global, "navigator", {
+      value: {
+        serviceWorker: {
+          register: registerMock,
+        },
+      },
+      writable: true,
+    });
+
+    render(<ServiceWorkerRegister />);
+
+    // Dispatch load event to trigger registration callback
+    window.dispatchEvent(new Event("load"));
+
+    // Allow promise rejection to propagate
+    await new Promise(process.nextTick);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith("ServiceWorker registration failed:", error);
+
+    consoleWarnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Added test to cover the case where `navigator.serviceWorker.register` fails and logs to console.warn.

---
*PR created automatically by Jules for task [8809165574041124390](https://jules.google.com/task/8809165574041124390) started by @handism*