### PR TITLE
🧪 Add tests for MapController.tsx

### DIFF
--- a/frontend/src/components/sauna-map/components/MapController.test.tsx
+++ b/frontend/src/components/sauna-map/components/MapController.test.tsx
@@ -1,0 +1,106 @@
+import { render, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { MapController } from "./MapController";
+import * as reactLeaflet from "react-leaflet";
+import * as motion from "../utils/motion";
+
+vi.mock("react-leaflet", () => ({
+  useMap: vi.fn(),
+}));
+
+// We must mock the module before we can spy on its exports in ES modules
+vi.mock("../utils/motion", () => ({
+  prefersReducedMotion: vi.fn(),
+}));
+
+describe("MapController", () => {
+  let mockMap: { getZoom: ReturnType<typeof vi.fn>; flyTo: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    mockMap = {
+      getZoom: vi.fn(),
+      flyTo: vi.fn(),
+    };
+    // The cast is needed because useMap expects a full Map instance,
+    // but we only implement the methods we need
+    vi.spyOn(reactLeaflet, "useMap").mockReturnValue(mockMap as unknown as ReturnType<typeof reactLeaflet.useMap>);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it("does nothing when target is null", () => {
+    render(<MapController target={null} />);
+    expect(mockMap.getZoom).not.toHaveBeenCalled();
+    expect(mockMap.flyTo).not.toHaveBeenCalled();
+  });
+
+  it("flies to target with zoom 14 when current zoom is less than 14", () => {
+    mockMap.getZoom.mockReturnValue(10);
+    vi.spyOn(motion, "prefersReducedMotion").mockReturnValue(false);
+
+    render(<MapController target={{ lat: 35.0, lng: 139.0 }} />);
+
+    expect(mockMap.flyTo).toHaveBeenCalledWith(
+      [35.0, 139.0],
+      14,
+      { animate: true, duration: 1.2 }
+    );
+  });
+
+  it("flies to target with current zoom when current zoom is 14 or greater", () => {
+    mockMap.getZoom.mockReturnValue(16);
+    vi.spyOn(motion, "prefersReducedMotion").mockReturnValue(false);
+
+    render(<MapController target={{ lat: 35.0, lng: 139.0 }} />);
+
+    expect(mockMap.flyTo).toHaveBeenCalledWith(
+      [35.0, 139.0],
+      16,
+      { animate: true, duration: 1.2 }
+    );
+  });
+
+  it("applies correct mobile offset for zoom < 15", () => {
+    mockMap.getZoom.mockReturnValue(14);
+    vi.spyOn(motion, "prefersReducedMotion").mockReturnValue(false);
+
+    render(<MapController target={{ lat: 35.0, lng: 139.0 }} isMobile={true} />);
+
+    // latOffset for zoom < 15 is 0.0045
+    expect(mockMap.flyTo).toHaveBeenCalledWith(
+      [35.0 - 0.0045, 139.0],
+      14,
+      { animate: true, duration: 1.2 }
+    );
+  });
+
+  it("applies correct mobile offset for zoom >= 15", () => {
+    mockMap.getZoom.mockReturnValue(15);
+    vi.spyOn(motion, "prefersReducedMotion").mockReturnValue(false);
+
+    render(<MapController target={{ lat: 35.0, lng: 139.0 }} isMobile={true} />);
+
+    // latOffset for zoom >= 15 is 0.0025
+    expect(mockMap.flyTo).toHaveBeenCalledWith(
+      [35.0 - 0.0025, 139.0],
+      15,
+      { animate: true, duration: 1.2 }
+    );
+  });
+
+  it("respects prefersReducedMotion to disable animations", () => {
+    mockMap.getZoom.mockReturnValue(14);
+    vi.spyOn(motion, "prefersReducedMotion").mockReturnValue(true);
+
+    render(<MapController target={{ lat: 35.0, lng: 139.0 }} />);
+
+    expect(mockMap.flyTo).toHaveBeenCalledWith(
+      [35.0, 139.0],
+      14,
+      { animate: false, duration: 1.2 }
+    );
+  });
+});


### PR DESCRIPTION
# 🧪 Add tests for MapController.tsx

🎯 **What:** The testing gap addressed
The `MapController.tsx` component is responsible for animating the map's viewport to focus on a target location using React Leaflet's `useMap` hook. Before this change, the component lacked test coverage, which left its zoom calculations, mobile offsetting logic, and motion accessibility considerations untested.

📊 **Coverage:** What scenarios are now tested
The newly added `MapController.test.tsx` file provides thorough unit tests covering all branch logic within the component:
- Handles `null` targets gracefully by returning early.
- Applies a zoom level of 14 when the current zoom is below 14.
- Maintains the current zoom level when it is 14 or above.
- Applies a mobile offset of `0.0045` for zoom levels below 15.
- Applies a mobile offset of `0.0025` for zoom levels 15 and above.
- Respects the OS-level "prefers reduced motion" accessibility setting by disabling map animation.

✨ **Result:** The improvement in test coverage
The `MapController` component is now fully covered by unit tests, increasing overall test coverage. Its dependencies, including `react-leaflet` and the `prefersReducedMotion` utility, are properly mocked to allow for isolated and deterministic assertions. This provides a safety net that protects against regressions in mobile styling and accessibility features during future refactors.

---
*PR created automatically by Jules for task [15616063916590400033](https://jules.google.com/task/15616063916590400033) started by @handism*