### PR TITLE
🔒 fix: Resolve Mass Assignment Vulnerability in Import API

### DIFF
--- a/backend/app/controllers/api/v1/imports_controller.rb
+++ b/backend/app/controllers/api/v1/imports_controller.rb
@@ -22,7 +22,14 @@ module Api
           payload.each do |raw|
             raise InvalidPayload, "取り込むデータは記録の配列で指定してください。" unless raw.is_a?(ActionController::Parameters)
 
-            attributes = raw.permit!.to_h.deep_symbolize_keys
+            # 許可キーは SaunaVisitsController#visit_params と揃える（エクスポートしたJSONを
+            # そのまま取り込むため、lockVersion / appendHistory も届く）
+            attributes = raw.permit(
+              :id, :name, :lat, :lng, :area, :status, :date, :comment, :rating, :image,
+              :appendHistory, :lockVersion, :visitCount, tags: [],
+              history: [ :id, :date, :comment, :rating, :image ]
+            ).to_h.deep_symbolize_keys
+
             external_id = attributes[:id].to_s
             raise InvalidPayload, "IDがない記録は取り込めません。" if external_id.blank?
 

--- a/backend/test/integration/api_v1_imports_test.rb
+++ b/backend/test/integration/api_v1_imports_test.rb
@@ -156,6 +156,27 @@ class ApiV1ImportsTest < ActionDispatch::IntegrationTest
     assert_equal 0, owner.sauna_visits.count
   end
 
+  test "許可していない属性は取り込まない" do
+    csrf = sign_in
+    other = User.create!(google_subject: "other-subject", email: "other@example.com")
+    # 未許可キーの扱いはテスト環境の設定に左右されるため、ここでは本番と同じ「黙って捨てる」で検証する
+    original = ActionController::Parameters.action_on_unpermitted_parameters
+    ActionController::Parameters.action_on_unpermitted_parameters = false
+
+    imported = valid_attributes.merge(id: "legacy-mass-assign", user_id: other.id, created_at: "2000-01-01")
+
+    post "/api/v1/sauna_visits/imports", params: { saunaVisits: [ imported ] },
+      headers: csrf_header(csrf), as: :json
+
+    assert_response :success
+    visit = owner.sauna_visits.sole
+    assert_equal owner.id, visit.user_id
+    assert_operator visit.created_at, :>, 1.day.ago
+    assert_equal 0, other.sauna_visits.count
+  ensure
+    ActionController::Parameters.action_on_unpermitted_parameters = original
+  end
+
   test "インポートにもCSRFトークンを要求する" do
     sign_in
     post "/api/v1/sauna_visits/imports", params: { saunaVisits: [ valid_attributes.merge(id: "x") ] }, as: :json


### PR DESCRIPTION
🎯 **What:** 
The vulnerability fixed is a mass assignment risk in `ImportsController`. Previously, the code used `raw.permit!` to blindly accept all parameters in the incoming JSON payload for sauna visits.

⚠️ **Risk:** 
If left unfixed, this mass assignment vulnerability could allow a malicious user to inject arbitrary attributes into the database by supplying unexpected parameters in the import JSON.

🛡️ **Solution:** 
Replaced `raw.permit!` with explicitly permitted attributes, matching the strong parameters pattern used in `SaunaVisitsController#visit_params`. This securely locks down the API.

---
*PR created automatically by Jules for task [15903449293524214177](https://jules.google.com/task/15903449293524214177) started by @handism*