### PR TITLE
🧪 Add Test for LocationPicker

### DIFF
--- a/frontend/src/components/sauna-map/components/LocationPicker.test.tsx
+++ b/frontend/src/components/sauna-map/components/LocationPicker.test.tsx
@@ -1,0 +1,50 @@
+import { render, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { LocationPicker } from "./LocationPicker";
+
+// Mock react-leaflet's useMapEvents
+const mockUseMapEvents = vi.fn();
+vi.mock("react-leaflet", () => ({
+  useMapEvents: (handlers: unknown) => mockUseMapEvents(handlers),
+}));
+
+describe("LocationPicker", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("registers a click event and calls onLocationSelect with correct coordinates", () => {
+    const mockOnLocationSelect = vi.fn();
+
+    // Render the component
+    render(<LocationPicker onLocationSelect={mockOnLocationSelect} />);
+
+    // Verify useMapEvents was called
+    expect(mockUseMapEvents).toHaveBeenCalledTimes(1);
+
+    // Extract the handlers passed to useMapEvents
+    const handlers = mockUseMapEvents.mock.calls[0][0];
+    expect(handlers).toHaveProperty("click");
+
+    // Simulate a map click event
+    const mockEvent = {
+      latlng: {
+        lat: 35.6812,
+        lng: 139.7671,
+      },
+    };
+
+    handlers.click(mockEvent);
+
+    // Verify onLocationSelect was called with the correct lat and lng
+    expect(mockOnLocationSelect).toHaveBeenCalledTimes(1);
+    expect(mockOnLocationSelect).toHaveBeenCalledWith(35.6812, 139.7671);
+  });
+
+  it("renders null", () => {
+    const { container } = render(<LocationPicker onLocationSelect={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
Adds a missing test file (`LocationPicker.test.tsx`) for the `LocationPicker` component located at `frontend/src/components/sauna-map/components/LocationPicker.tsx`. This addresses a gap in the test suite where the map clicking logic in `LocationPicker` wasn't being verified. It tests event registration, callback invocation on simulated click, and rendering correctness.

---
*PR created automatically by Jules for task [13197761992922241011](https://jules.google.com/task/13197761992922241011) started by @handism*