### PR TITLE
🧹 [refactor] Extract serialization logic in SaunaVisitSerializer

### DIFF
--- a/backend/app/serializers/sauna_visit_serializer.rb
+++ b/backend/app/serializers/sauna_visit_serializer.rb
@@ -4,26 +4,50 @@ class SaunaVisitSerializer
   end
 
   def as_json(*)
-    latest = @visit.visit_history_entries.last
     {
-      id: @visit.external_id,
-      name: @visit.name,
-      lat: @visit.latitude.to_f,
-      lng: @visit.longitude.to_f,
-      area: @visit.area,
-      status: @visit.status,
-      tags: @visit.tags,
-      visitCount: @visit.visit_count,
-      lockVersion: @visit.lock_version,
-      date: latest&.visited_on&.iso8601 || "",
-      comment: latest&.comment || "",
-      rating: latest&.rating&.to_f,
-      image: image_url(latest),
-      history: @visit.visit_history_entries.map { |entry| history_json(entry) }
+      **base_attributes,
+      **location_attributes,
+      **latest_visit_attributes,
+      **history_attributes
     }.compact
   end
 
   private
+
+  def base_attributes
+    {
+      id: @visit.external_id,
+      name: @visit.name,
+      area: @visit.area,
+      status: @visit.status,
+      tags: @visit.tags,
+      visitCount: @visit.visit_count,
+      lockVersion: @visit.lock_version
+    }
+  end
+
+  def location_attributes
+    {
+      lat: @visit.latitude.to_f,
+      lng: @visit.longitude.to_f
+    }
+  end
+
+  def latest_visit_attributes
+    latest = @visit.visit_history_entries.last
+    {
+      date: latest&.visited_on&.iso8601 || "",
+      comment: latest&.comment || "",
+      rating: latest&.rating&.to_f,
+      image: image_url(latest)
+    }
+  end
+
+  def history_attributes
+    {
+      history: @visit.visit_history_entries.map { |entry| history_json(entry) }
+    }
+  end
 
   def history_json(entry)
     {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted serialization logic from a monolithic `as_json` method in `SaunaVisitSerializer` into four smaller, focused private helper methods (`base_attributes`, `location_attributes`, `latest_visit_attributes`, and `history_attributes`).

💡 **Why:** How this improves maintainability
The original `as_json` method was large and mixed various concerns (base attributes, nested object extraction, history serialization). Splitting it makes it much easier to read, test, and modify specific segments of the serialized payload independently in the future.

✅ **Verification:** How you confirmed the change is safe
Visually verified the resulting `as_json` hash structure. Ran a mock script in Ruby testing the combined output matches the previous output using the `**` hash merging syntax.

✨ **Result:** The improvement achieved
A cleaner, more modular `SaunaVisitSerializer` that preserves existing functionality and is easier to understand.

---
*PR created automatically by Jules for task [16285660521611512162](https://jules.google.com/task/16285660521611512162) started by @handism*