### PR TITLE
🔒 Security Fix: Require explicit Postgres Password in Production

### DIFF
--- a/backend/config/database.yml
+++ b/backend/config/database.yml
@@ -18,3 +18,4 @@ test:
 production:
   <<: *default
   database: <%= ENV.fetch("POSTGRES_DB", "sauna_itta_production") %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD") %>

--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,0 +1,10 @@
+# 🔒 Security Fix: Require explicit Postgres Password in Production
+
+## 🎯 What
+The `backend/config/database.yml` file previously allowed the production environment to inherit the default database password (`sauna_itta`), which was hardcoded in the file. I have updated the `production` section of the database configuration to explicitly override the `password` field and require the `POSTGRES_PASSWORD` environment variable without a fallback.
+
+## ⚠️ Risk
+Leaving a hardcoded default password for the production database could allow an attacker to gain unauthorized access to sensitive production data if the `POSTGRES_PASSWORD` environment variable is not explicitly set or if the configuration is inadvertently exposed.
+
+## 🛡️ Solution
+By explicitly requiring the `POSTGRES_PASSWORD` environment variable using `<%= ENV.fetch("POSTGRES_PASSWORD") %>` (without a default fallback value) in the `production` block, the application will now fail to boot if the password is not provided. This ensures that a secure password must be deliberately configured for production environments, removing the risk of accidentally relying on a hardcoded default.


### PR DESCRIPTION
The `backend/config/database.yml` file previously allowed the production environment to inherit the default database password (`sauna_itta`), which was hardcoded in the file. I have updated the `production` section of the database configuration to explicitly override the `password` field and require the `POSTGRES_PASSWORD` environment variable without a fallback.

By explicitly requiring the `POSTGRES_PASSWORD` environment variable using `<%= ENV.fetch("POSTGRES_PASSWORD") %>` (without a default fallback value) in the `production` block, the application will now fail to boot if the password is not provided. This ensures that a secure password must be deliberately configured for production environments, removing the risk of accidentally relying on a hardcoded default.

---
*PR created automatically by Jules for task [14244288064620103474](https://jules.google.com/task/14244288064620103474) started by @handism*