### PR TITLE
🧹 [Code Health] Refactor VisitForm for improved readability and maintainability

### DIFF
--- a/frontend/src/components/sauna-map/components/form/VisitForm.tsx
+++ b/frontend/src/components/sauna-map/components/form/VisitForm.tsx
@@ -1,5 +1,4 @@
 import { Dispatch, FormEvent, SetStateAction } from "react";
-import { Check, Save, X, Trash2, Info, Loader2 } from "lucide-react";
 import { VisitFormState, VisitHistoryEntry } from "../../types";
 import { VisitHistorySection } from "./VisitHistorySection";
 import { VisitTagsField } from "./VisitTagsField";
@@ -12,6 +11,9 @@ import {
   NameField,
   AreaField,
   DateField,
+  HistoryAppendField,
+  CommentField,
+  FormActions,
 } from "./VisitFormFields";
 import { useSaunaEditor, useSaunaEditorForm, useSaunaMapActions } from "../../context";
 import { GeocodingResult } from "../../utils/geocoding";
@@ -89,21 +91,12 @@ export function VisitFormView({
       )}
 
       {editingId && form.status === "visited" && (
-        <div className="form-group form-group--checkbox">
-          <label className="checkbox-row">
-            <input
-              type="checkbox"
-              checked={form.appendHistory}
-              onChange={(e) =>
-                setForm((prev) => ({ ...prev, appendHistory: e.target.checked }))
-              }
-            />
-            <span>新しい訪問記録として追加する（訪問回数+1）</span>
-          </label>
-          <p className="form-hint">
-            チェックを入れると、今回の内容が新しい訪問履歴として保存されます。チェックを外すと前回の記録を修正します。
-          </p>
-        </div>
+        <HistoryAppendField
+          appendHistory={form.appendHistory}
+          onChange={(appendHistory) =>
+            setForm((prev) => ({ ...prev, appendHistory }))
+          }
+        />
       )}
 
       <NameField
@@ -135,23 +128,11 @@ export function VisitFormView({
         onChange={(tagsText) => setForm((prev) => ({ ...prev, tagsText }))}
       />
 
-      <div className="form-group">
-        <label htmlFor="visit-comment">
-          {form.status === "wishlist" ? "メモ" : "感想・メモ"}
-        </label>
-        <textarea
-          id="visit-comment"
-          className="input textarea"
-          rows={3}
-          value={form.comment}
-          onChange={(e) => setForm((prev) => ({ ...prev, comment: e.target.value }))}
-          placeholder={
-            form.status === "wishlist"
-              ? "行きたい理由や気になっているポイント..."
-              : "ととのい具合、水風呂の温度、外気浴の雰囲気など..."
-          }
-        />
-      </div>
+      <CommentField
+        status={form.status}
+        comment={form.comment}
+        onChange={(comment) => setForm((prev) => ({ ...prev, comment }))}
+      />
 
       {form.status === "visited" && (
         <VisitImageField
@@ -162,40 +143,13 @@ export function VisitFormView({
         />
       )}
 
-      <div className="form-actions">
-        <button
-          type="submit"
-          className="btn btn-primary"
-          disabled={submitBlockedReason !== null}
-          title={submitBlockedReason ?? undefined}
-          aria-describedby={submitBlockedReason ? "submit-blocked-reason" : undefined}
-        >
-          {saving ? <Loader2 size={18} className="spin-icon" /> : editingId ? <Check size={18} /> : <Save size={18} />}
-          <span>{saving ? "保存中..." : editingId ? "更新する" : "保存する"}</span>
-        </button>
-        {submitBlockedReason && (
-          <p className="form-hint form-hint--blocked" id="submit-blocked-reason" role="status">
-            <Info size={13} aria-hidden="true" />
-            {submitBlockedReason}
-          </p>
-        )}
-        <div className={`form-actions-secondary ${!editingId ? "form-actions-secondary--single" : ""}`}>
-          {editingId && (
-            <button
-              type="button"
-              className="btn btn-danger btn-delete"
-              onClick={onDelete}
-            >
-              <Trash2 size={16} />
-              <span>削除</span>
-            </button>
-          )}
-          <button type="button" className="btn btn-ghost" onClick={onCancel}>
-            <X size={16} />
-            <span>キャンセル</span>
-          </button>
-        </div>
-      </div>
+      <FormActions
+        saving={saving}
+        editingId={editingId}
+        submitBlockedReason={submitBlockedReason}
+        onDelete={onDelete}
+        onCancel={onCancel}
+      />
     </form>
   );
 }

--- a/frontend/src/components/sauna-map/components/form/VisitFormFields.tsx
+++ b/frontend/src/components/sauna-map/components/form/VisitFormFields.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, Star } from "lucide-react";
+import { Check, Save, X, Trash2, Info, Loader2, CheckCircle2, Star } from "lucide-react";
 import { LocationSearchInput } from "./LocationSearchInput";
 import { GeocodingResult } from "../../utils/geocoding";
 import { getDateDaysAgo } from "../../utils/date";
@@ -40,6 +40,111 @@ export function LocationSearchField({
         inputId="visit-location-search"
         onSelectLocation={onSelectLocation}
       />
+    </div>
+  );
+}
+
+export function HistoryAppendField({
+  appendHistory,
+  onChange,
+}: {
+  appendHistory: boolean;
+  onChange: (appendHistory: boolean) => void;
+}) {
+  return (
+    <div className="form-group form-group--checkbox">
+      <label className="checkbox-row">
+        <input
+          type="checkbox"
+          checked={appendHistory}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+        <span>新しい訪問記録として追加する（訪問回数+1）</span>
+      </label>
+      <p className="form-hint">
+        チェックを入れると、今回の内容が新しい訪問履歴として保存されます。チェックを外すと前回の記録を修正します。
+      </p>
+    </div>
+  );
+}
+
+export function CommentField({
+  status,
+  comment,
+  onChange,
+}: {
+  status: "visited" | "wishlist";
+  comment: string;
+  onChange: (comment: string) => void;
+}) {
+  return (
+    <div className="form-group">
+      <label htmlFor="visit-comment">
+        {status === "wishlist" ? "メモ" : "感想・メモ"}
+      </label>
+      <textarea
+        id="visit-comment"
+        className="input textarea"
+        rows={3}
+        value={comment}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={
+          status === "wishlist"
+            ? "行きたい理由や気になっているポイント..."
+            : "ととのい具合、水風呂の温度、外気浴の雰囲気など..."
+        }
+      />
+    </div>
+  );
+}
+
+export function FormActions({
+  saving,
+  editingId,
+  submitBlockedReason,
+  onDelete,
+  onCancel,
+}: {
+  saving: boolean;
+  editingId: string | null;
+  submitBlockedReason: string | null;
+  onDelete: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="form-actions">
+      <button
+        type="submit"
+        className="btn btn-primary"
+        disabled={submitBlockedReason !== null}
+        title={submitBlockedReason ?? undefined}
+        aria-describedby={submitBlockedReason ? "submit-blocked-reason" : undefined}
+      >
+        {saving ? <Loader2 size={18} className="spin-icon" /> : editingId ? <Check size={18} /> : <Save size={18} />}
+        <span>{saving ? "保存中..." : editingId ? "更新する" : "保存する"}</span>
+      </button>
+      {submitBlockedReason && (
+        <p className="form-hint form-hint--blocked" id="submit-blocked-reason" role="status">
+          <Info size={13} aria-hidden="true" />
+          {submitBlockedReason}
+        </p>
+      )}
+      <div className={`form-actions-secondary ${!editingId ? "form-actions-secondary--single" : ""}`}>
+        {editingId && (
+          <button
+            type="button"
+            className="btn btn-danger btn-delete"
+            onClick={onDelete}
+          >
+            <Trash2 size={16} />
+            <span>削除</span>
+          </button>
+        )}
+        <button type="button" className="btn btn-ghost" onClick={onCancel}>
+          <X size={16} />
+          <span>キャンセル</span>
+        </button>
+      </div>
     </div>
   );
 }

--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,0 +1,21 @@
+# 🧹 [Code Health] Refactor VisitForm for improved readability and maintainability
+
+## 🎯 What
+This PR addresses a code health issue in `frontend/src/components/sauna-map/components/form/VisitForm.tsx` where the `VisitFormView` component had become excessively large and complex (170+ lines).
+
+The following inline blocks have been extracted into focused, reusable pure components inside `VisitFormFields.tsx`:
+- `HistoryAppendField`: Handles the "History Append" checkbox toggle logic.
+- `CommentField`: Handles the memo/comment textarea, dynamically adjusting placeholder text based on status.
+- `FormActions`: Encapsulates the save, delete, and cancel buttons along with their loading and blocked states.
+
+## 💡 Why
+Extracting these parts into pure components significantly reduces the size and complexity of `VisitFormView`. This makes the main form component much easier to read and maintain. Since these child components only rely on props for their state and event handling, they are fully decoupled from the context, minimizing architectural changes while maximizing clarity.
+
+## ✅ Verification
+- Ensured all icons (`Check`, `Save`, `X`, `Trash2`, `Info`, `Loader2`) were correctly migrated to `VisitFormFields.tsx`.
+- Ran `npm run typecheck` and `npm run lint` in the `frontend/` directory to ensure type safety and code style compliance.
+- Ran the full frontend test suite (`npx vitest run`) which passed completely (533 passed), including specific checks for `VisitForm.test.tsx` and `VisitFormFields.test.tsx`.
+- Successfully completed Code Review with an outcome of `#Correct#`, confirming the refactoring safely abstracted logic without breaking or modifying existing behavior.
+
+## ✨ Result
+`VisitForm.tsx` is now much cleaner and more readable. The extracted components effectively encapsulate distinct UI sections, paving the way for easier testing and future updates to the form fields.


### PR DESCRIPTION
This PR addresses a code health issue in `frontend/src/components/sauna-map/components/form/VisitForm.tsx` where the `VisitFormView` component had become excessively large and complex (170+ lines). 

The following inline blocks have been extracted into focused, reusable pure components inside `VisitFormFields.tsx`:
- `HistoryAppendField`: Handles the "History Append" checkbox toggle logic.
- `CommentField`: Handles the memo/comment textarea, dynamically adjusting placeholder text based on status.
- `FormActions`: Encapsulates the save, delete, and cancel buttons along with their loading and blocked states.

## 💡 Why
Extracting these parts into pure components significantly reduces the size and complexity of `VisitFormView`. This makes the main form component much easier to read and maintain. Since these child components only rely on props for their state and event handling, they are fully decoupled from the context, minimizing architectural changes while maximizing clarity.

## ✅ Verification
- Ensured all icons (`Check`, `Save`, `X`, `Trash2`, `Info`, `Loader2`) were correctly migrated to `VisitFormFields.tsx`.
- Ran `npm run typecheck` and `npm run lint` in the `frontend/` directory to ensure type safety and code style compliance.
- Ran the full frontend test suite (`npx vitest run`) which passed completely (533 passed), including specific checks for `VisitForm.test.tsx` and `VisitFormFields.test.tsx`.
- Successfully completed Code Review with an outcome of `#Correct#`, confirming the refactoring safely abstracted logic without breaking or modifying existing behavior.

## ✨ Result
`VisitForm.tsx` is now much cleaner and more readable. The extracted components effectively encapsulate distinct UI sections, paving the way for easier testing and future updates to the form fields.

---
*PR created automatically by Jules for task [3570074694241716294](https://jules.google.com/task/3570074694241716294) started by @handism*