### PR TITLE
🧹 [Code Health] Extract complex virtualized list setup to a custom hook

### DIFF
--- a/frontend/src/components/sauna-map/components/list/VisitList.tsx
+++ b/frontend/src/components/sauna-map/components/list/VisitList.tsx
@@ -1,13 +1,13 @@
-import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { SaunaVisit, VisitFilters } from "../../types";
 import { ImageLightbox } from "../common/common";
 import { useImageLightbox } from "../../hooks/useImageLightbox";
+import { useIncrementalList } from "../../hooks/useIncrementalList";
 import { VisitCompactItem } from "./VisitCompactItem";
 import { VisitCardItem } from "./VisitCardItem";
 import { VisitListHeader, ViewMode } from "./VisitListHeader";
 import { VisitListSearch } from "./VisitListSearch";
 import { VisitListEmpty } from "./VisitListEmpty";
-import { getScrollBehavior } from "../../utils/motion";
 import { readStorage, writeStorage } from "../../utils/storage";
 import {
   useVisitsCRUD,
@@ -58,10 +58,6 @@ export function VisitListView({
   hoveredId,
   onHoverVisit,
 }: VisitListViewProps) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
-  // ユーザー操作で伸ばした分の追加件数。実際の描画件数はレンダー中に導出する
-  const [extraCount, setExtraCount] = useState(0);
   const { lightboxSrc, openImage, closeImage } = useImageLightbox();
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     const saved = readStorage(STORAGE_KEY);
@@ -73,47 +69,18 @@ export function VisitListView({
     writeStorage(STORAGE_KEY, mode);
   };
 
-  // 選択された記録が初期ウィンドウの外にある場合はそこまで描画を伸ばす。
-  // フィルター変更時に extraCount は保持されるが、件数が減れば hasMore が false になり
-  // 番兵も消えるため、描画数は常に filteredVisits の範囲に収まる。
-  const selectedIndex = selectedId
-    ? filteredVisits.findIndex((v) => v.id === selectedId)
-    : -1;
-  const visibleCount = Math.max(
-    INITIAL_RENDER_COUNT + extraCount,
-    selectedIndex + 1
+  const {
+    containerRef,
+    sentinelRef,
+    renderedVisits,
+    hasMore,
+    loadMore,
+  } = useIncrementalList(
+    filteredVisits,
+    selectedId,
+    INITIAL_RENDER_COUNT,
+    CHUNK_SIZE
   );
-  const renderedVisits = filteredVisits.slice(0, visibleCount);
-  const hasMore = filteredVisits.length > renderedVisits.length;
-
-  useEffect(() => {
-    if (!selectedId || !containerRef.current) return;
-    const targetEl = containerRef.current.querySelector<HTMLElement>(
-      `[data-visit-id="${selectedId}"]`
-    );
-    // jsdom など scrollIntoView 未実装の環境を考慮して optional call にする
-    targetEl?.scrollIntoView?.({ behavior: getScrollBehavior(), block: "center" });
-  }, [selectedId, visibleCount]);
-
-  // 末尾の番兵が見えたら次のチャンクを描画する
-  useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel || typeof IntersectionObserver !== "function") return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          setExtraCount((prev) => prev + CHUNK_SIZE);
-        }
-      },
-      // スクロールコンテナは .sidebar-content / .bottom-sheet-content 側なので
-      // root は指定せずビューポート基準で監視する
-      { rootMargin: "200px" }
-    );
-    observer.observe(sentinel);
-
-    return () => observer.disconnect();
-  }, [visibleCount, filteredVisits.length]);
 
   return (
     <div className="sauna-list" ref={containerRef}>
@@ -183,7 +150,7 @@ export function VisitListView({
           <button
             type="button"
             className="btn btn-ghost list-load-more-btn"
-            onClick={() => setExtraCount((prev) => prev + CHUNK_SIZE)}
+            onClick={loadMore}
           >
             さらに表示（残り {filteredVisits.length - renderedVisits.length} 件）
           </button>

--- a/frontend/src/components/sauna-map/hooks/useIncrementalList.test.ts
+++ b/frontend/src/components/sauna-map/hooks/useIncrementalList.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useIncrementalList } from "./useIncrementalList";
+import { SaunaVisit } from "../types";
+
+vi.mock("../utils/motion", () => ({
+  getScrollBehavior: vi.fn(() => "auto"),
+}));
+
+const makeVisit = (index: number): SaunaVisit => ({
+  id: `visit-${index}`,
+  name: `サウナ ${index}`,
+  lat: 35.68,
+  lng: 139.76,
+  date: "2026-07-25",
+  rating: 5,
+  comment: "",
+  tags: [],
+  image: "",
+  status: "visited",
+  area: "東京",
+  visitCount: 1,
+});
+
+describe("useIncrementalList", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        observe() {}
+        disconnect() {}
+        unobserve() {}
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("should render initial count", () => {
+    const visits = Array.from({ length: 50 }, (_, i) => makeVisit(i));
+    const { result } = renderHook(() =>
+      useIncrementalList(visits, null, 10, 10)
+    );
+
+    expect(result.current.renderedVisits.length).toBe(10);
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it("should load more when requested", () => {
+    const visits = Array.from({ length: 50 }, (_, i) => makeVisit(i));
+    const { result } = renderHook(() =>
+      useIncrementalList(visits, null, 10, 10)
+    );
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    expect(result.current.renderedVisits.length).toBe(20);
+  });
+
+  it("should expand to show selected item", () => {
+    const visits = Array.from({ length: 50 }, (_, i) => makeVisit(i));
+    const { result } = renderHook(() =>
+      useIncrementalList(visits, "visit-25", 10, 10)
+    );
+
+    expect(result.current.renderedVisits.length).toBe(26);
+  });
+});

--- a/frontend/src/components/sauna-map/hooks/useIncrementalList.ts
+++ b/frontend/src/components/sauna-map/hooks/useIncrementalList.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from "react";
+import { SaunaVisit } from "../types";
+import { getScrollBehavior } from "../utils/motion";
+
+export function useIncrementalList(
+  filteredVisits: SaunaVisit[],
+  selectedId: string | null,
+  initialRenderCount: number,
+  chunkSize: number
+) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const [extraCount, setExtraCount] = useState(0);
+
+  const selectedIndex = selectedId
+    ? filteredVisits.findIndex((v) => v.id === selectedId)
+    : -1;
+  const visibleCount = Math.max(
+    initialRenderCount + extraCount,
+    selectedIndex + 1
+  );
+  const renderedVisits = filteredVisits.slice(0, visibleCount);
+  const hasMore = filteredVisits.length > renderedVisits.length;
+
+  useEffect(() => {
+    if (!selectedId || !containerRef.current) return;
+    const targetEl = containerRef.current.querySelector<HTMLElement>(
+      `[data-visit-id="${selectedId}"]`
+    );
+    targetEl?.scrollIntoView?.({ behavior: getScrollBehavior(), block: "center" });
+  }, [selectedId, visibleCount]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel || typeof IntersectionObserver !== "function") return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setExtraCount((prev) => prev + chunkSize);
+        }
+      },
+      { rootMargin: "200px" }
+    );
+    observer.observe(sentinel);
+
+    return () => observer.disconnect();
+  }, [visibleCount, filteredVisits.length, chunkSize]);
+
+  const loadMore = () => setExtraCount((prev) => prev + chunkSize);
+
+  return {
+    containerRef,
+    sentinelRef,
+    renderedVisits,
+    hasMore,
+    loadMore,
+  };
+}

--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,0 +1,19 @@
+# 🧹 [Code Health] Extract complex virtualized list setup to a custom hook
+
+## 🎯 What
+This PR addresses code health issues in `frontend/src/components/sauna-map/components/list/VisitList.tsx` by extracting the complex incremental rendering logic (often referred to as virtualized list setup) into a new custom hook, `useIncrementalList`.
+
+## 💡 Why
+`VisitList.tsx` was handling too many responsibilities, including its primary job of UI rendering and the low-level DOM intersection and scrolling logic required to lazily load and auto-scroll the visits list.
+By extracting this complex setup into `useIncrementalList`:
+*   **Maintainability**: `VisitList.tsx` becomes much cleaner and focused solely on what it renders. The file size and cognitive complexity are significantly reduced.
+*   **Testability**: The incremental list logic (Intersection Observer behavior, chunked loading, selection scrolling) can now be tested in isolation inside `useIncrementalList.test.ts`, rather than relying solely on component-level DOM interaction tests.
+*   **Reusability**: If similar "load more on scroll" behavior is needed elsewhere, the hook is ready to be reused.
+
+## ✅ Verification
+- Verified that all unit tests still pass, including the original `VisitList.test.tsx` which tests the component's integration with the incremental rendering behavior.
+- Added comprehensive unit tests for the newly extracted `useIncrementalList` hook to ensure correct item chunking and `IntersectionObserver` mock handling.
+- Ran `npm run lint` inside the `frontend` directory, which successfully passed after cleaning up unused imports in `VisitList.tsx`.
+
+## ✨ Result
+The codebase is cleaner, with better separation of concerns between state/intersection management and UI rendering. No external behavior or performance was changed, preserving existing functionality entirely.


### PR DESCRIPTION
This PR addresses code health issues in `frontend/src/components/sauna-map/components/list/VisitList.tsx` by extracting the complex incremental rendering logic into a new custom hook, `useIncrementalList`.

### Why
`VisitList.tsx` was handling too many responsibilities, including UI rendering and low-level DOM intersection/scrolling logic. Extracting this setup improves maintainability, testability in isolation, and allows for potential reusability.

### Verification
- Verified all unit tests still pass (including `VisitList.test.tsx`).
- Added tests for `useIncrementalList`.
- Passed linting.

---
*PR created automatically by Jules for task [10366024903263603998](https://jules.google.com/task/10366024903263603998) started by @handism*