### PR TITLE
Fix unapplied review feedback in CSS and SaunaMarkerPopup

### DIFF
--- a/frontend/src/components/sauna-map/components/map/SaunaMarkerPopup.test.tsx
+++ b/frontend/src/components/sauna-map/components/map/SaunaMarkerPopup.test.tsx
@@ -62,17 +62,17 @@ describe("SaunaMarkerPopup", () => {
     const dataUrl =
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
     const { rerender } = render(
-      <SaunaMarkerPopup visit={{ ...visit, image: dataUrl }} isWishlist={false} onEdit={vi.fn()} />,
+      <SaunaMarkerPopup visit={{ ...visit, image: dataUrl }} isWishlist={false} onEdit={vi.fn()} />
     );
-    expect(screen.getByRole("img", { name: "天空サウナ" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "天空サウナの写真を拡大表示" })).toBeInTheDocument();
 
     rerender(
       <SaunaMarkerPopup
         visit={{ ...visit, image: "javascript:alert(1)" }}
         isWishlist={false}
         onEdit={vi.fn()}
-      />,
+      />
     );
-    expect(screen.queryByRole("img", { name: "天空サウナ" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "天空サウナの写真を拡大表示" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/sauna-map/components/map/SaunaMarkerPopup.tsx
+++ b/frontend/src/components/sauna-map/components/map/SaunaMarkerPopup.tsx
@@ -1,16 +1,16 @@
 import { Navigation } from "lucide-react";
-import Image from "next/image";
 import { SaunaVisit } from "../../types";
 import { getDirectionsUrl, getVisitCount, sanitizeImageUrl } from "../../utils";
-import { RatingStars, WishlistChip } from "../common/common";
+import { RatingStars, VisitImagePreview, WishlistChip } from "../common/common";
 
 interface SaunaMarkerPopupProps {
   visit: SaunaVisit;
   isWishlist: boolean;
   onEdit: (visit: SaunaVisit) => void;
+  onOpenImage?: (src: string) => void;
 }
 
-export function SaunaMarkerPopup({ visit, isWishlist, onEdit }: SaunaMarkerPopupProps) {
+export function SaunaMarkerPopup({ visit, isWishlist, onEdit, onOpenImage }: SaunaMarkerPopupProps) {
   const visitCount = getVisitCount(visit);
   const imageUrl = sanitizeImageUrl(visit.image);
 
@@ -22,16 +22,11 @@ export function SaunaMarkerPopup({ visit, isWishlist, onEdit }: SaunaMarkerPopup
       </h3>
       {visit.area && <div className="popup-area">{visit.area}</div>}
       <RatingStars rating={visit.rating ?? 0} className="popup-rating" />
-      {imageUrl && (
-        <Image
-          src={imageUrl}
-          alt={visit.name}
-          className="popup-image"
-          width={400}
-          height={300}
-          unoptimized
-        />
-      )}
+      <VisitImagePreview
+        src={imageUrl}
+        alt={`${visit.name}の写真`}
+        onOpenImage={onOpenImage || (() => {})}
+      />
       <p className="popup-comment">{visit.comment}</p>
       <small className="popup-meta">
         {visit.date}

--- a/frontend/src/components/sauna-map/components/map/VisitMarkers.tsx
+++ b/frontend/src/components/sauna-map/components/map/VisitMarkers.tsx
@@ -7,6 +7,7 @@ import { getVisitCount, isWishlist } from "../../utils";
 import { getSaunaIcon } from "../common/markerIcon";
 import { flameIconSvg } from "../common/iconSvg";
 import { SaunaMarkerPopup } from "./SaunaMarkerPopup";
+import { useImageLightbox } from "../../hooks/useImageLightbox";
 
 interface VisitMarkersProps {
   visits: SaunaVisit[];
@@ -58,6 +59,8 @@ function VisitMarkersComponent({
   onEdit,
   onSelectVisit,
 }: VisitMarkersProps) {
+  const { openImage } = useImageLightbox();
+
   const renderMarker = useCallback(
     (visit: SaunaVisit) => {
       const visitCount = getVisitCount(visit);
@@ -89,12 +92,13 @@ function VisitMarkersComponent({
               visit={visit}
               isWishlist={wishlist}
               onEdit={onEdit}
+              onOpenImage={openImage}
             />
           </Popup>
         </Marker>
       );
     },
-    [editingId, hoveredId, onEdit, onSelectVisit, selectedId, showBadges],
+    [editingId, hoveredId, onEdit, onSelectVisit, openImage, selectedId, showBadges],
   );
 
   if (!enableClustering) {

--- a/frontend/src/components/sauna-map/styles/map.css
+++ b/frontend/src/components/sauna-map/styles/map.css
@@ -142,8 +142,8 @@
 
 .sauna-marker-pill--rating {
   background: rgba(30, 30, 30, 0.85);
-  color: #fbbf24;
-  border-color: rgba(251, 191, 36, 0.4);
+  color: var(--star-color);
+  border-color: color-mix(in srgb, var(--star-color) 40%, transparent);
 }
 
 .sauna-marker-pill--count {
@@ -154,7 +154,7 @@
 
 .sauna-marker-pill--wishlist {
   background: rgba(16, 185, 129, 0.9);
-  color: #ffffff;
+  color: #04241a;
   border-color: rgba(255, 255, 255, 0.5);
 }
 
@@ -324,6 +324,7 @@
   gap: 0.25rem;
   margin-left: 0.5rem;
   font-size: 0.75rem;
+  color: var(--accent-wishlist);
 }
 
 .wishlist-chip--compact {
@@ -338,13 +339,6 @@
 
 .popup-rating {
   font-size: 0.8rem;
-  margin-bottom: 0.5rem;
-}
-
-.popup-image {
-  width: 100%;
-  height: auto;
-  border-radius: var(--radius-sm);
   margin-bottom: 0.5rem;
 }
 

--- a/frontend/src/components/sauna-map/styles/modal.css
+++ b/frontend/src/components/sauna-map/styles/modal.css
@@ -94,7 +94,7 @@
 
 .share-rating {
   margin-top: 0.1rem;
-  color: var(--primary);
+  color: var(--star-color);
 }
 
 .share-tags {

--- a/frontend/src/components/sauna-map/styles/visit-card.css
+++ b/frontend/src/components/sauna-map/styles/visit-card.css
@@ -270,7 +270,7 @@
 .sauna-card-rating {
   font-size: 0.8rem;
   margin-bottom: 0.25rem;
-  color: var(--primary);
+  color: var(--star-color);
 }
 
 .sauna-tag-list {
@@ -436,7 +436,7 @@
   display: inline-flex;
   align-items: center;
   gap: 0.2rem;
-  color: var(--primary);
+  color: var(--star-color);
   font-weight: 600;
   font-size: 0.78rem;
 }

--- a/pr_proposal.md
+++ b/pr_proposal.md
@@ -1,0 +1,15 @@
+# PR Proposal: Fix unapplied review feedback
+
+## Description
+This PR addresses several review feedback items that were missed in previous commits, particularly concerning design token usage in CSS and component usage in `SaunaMarkerPopup`.
+
+## Changes Made
+*   Replaced hardcoded rating colors (`#fbbf24`, `var(--primary)`) with the correct design token `var(--star-color)` in `.sauna-marker-pill--rating`, `.sauna-card-rating`, `.history-rating`, and `.share-rating`.
+*   Fixed the `.wishlist-chip` and `.sauna-marker-pill--wishlist` colors to correctly use `var(--accent-wishlist)` and `#04241a` for improved contrast in light/dark themes.
+*   Updated `SaunaMarkerPopup.tsx` to use the `VisitImagePreview` component instead of a raw `<Image>` tag with an `onClick` handler for accessibility (keyboard interaction).
+*   Passed down `onOpenImage` from `useImageLightbox` down to `SaunaMarkerPopup` via `VisitMarkers`.
+*   Updated `SaunaMarkerPopup.test.tsx` to handle the new `onOpenImage` behavior correctly.
+
+## Verification
+*   Ran all unit tests to ensure that `VisitMarkers` and `SaunaMarkerPopup` are rendering successfully without breaking regressions.
+*   Verified that CSS rules and components pass the linter.


### PR DESCRIPTION
This PR addresses several review feedback items that were missed in previous commits, particularly concerning design token usage in CSS and component usage in `SaunaMarkerPopup`.

## Changes Made
*   Replaced hardcoded rating colors (`#fbbf24`, `var(--primary)`) with the correct design token `var(--star-color)` in `.sauna-marker-pill--rating`, `.sauna-card-rating`, `.history-rating`, and `.share-rating`.
*   Fixed the `.wishlist-chip` and `.sauna-marker-pill--wishlist` colors to correctly use `var(--accent-wishlist)` and `#04241a` for improved contrast in light/dark themes.
*   Updated `SaunaMarkerPopup.tsx` to use the `VisitImagePreview` component instead of a raw `<Image>` tag with an `onClick` handler for accessibility (keyboard interaction).
*   Passed down `onOpenImage` from `useImageLightbox` down to `SaunaMarkerPopup` via `VisitMarkers`.
*   Updated `SaunaMarkerPopup.test.tsx` to handle the new `onOpenImage` behavior correctly.

## Verification
*   Ran all unit tests to ensure that `VisitMarkers` and `SaunaMarkerPopup` are rendering successfully without breaking regressions.
*   Verified that CSS rules and components pass the linter.

---
*PR created automatically by Jules for task [14526289886455330854](https://jules.google.com/task/14526289886455330854) started by @handism*